### PR TITLE
chore: add required GitHub Actions permissions

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+permissions:
+  contents: write
+  security-events: read
 
 jobs:
   build:


### PR DESCRIPTION
Ensures every GitHub Actions workflow on `main` has:

```yaml
permissions:
  contents: write
  security-events: read
```

Existing unrelated permission entries are preserved.

Existing job-level permission overrides are also updated so they do not override and remove the required workflow permissions.

No triggers, jobs, steps, deployment environments, or push branch lists are intentionally changed.