### PR TITLE
chore: add Dependabot configuration and critical-vuln gate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# Dependabot config for .NET / NuGet API repos.
+# main is replaced by the rollout script with `develop` (if the
+# repo has that branch) or the repo's actual default branch otherwise.
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Amman"
+    open-pull-requests-limit: 10
+    groups:
+      nuget-minor-patch:
+        update-types: ["minor", "patch"]
+    labels:
+      - "dependencies"
+      - "nuget"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Amman"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types: ["minor", "patch"]
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/critical-vuln-check.yml
+++ b/.github/workflows/critical-vuln-check.yml
@@ -1,0 +1,38 @@
+# =============================================================================
+# Critical Dependabot Vulnerability Check — Caller template
+# =============================================================================
+# USAGE:
+#   Copy this file to your repo at .github/workflows/critical-vuln-check.yml.
+#   No REPLACE values needed — this template requires no customization.
+#
+# WHAT IT DOES:
+#   Runs on every PR targeting main or develop. Fails if the repository has
+#   any open CRITICAL-severity Dependabot alert.
+#
+#   Enforcement differs by target branch via each repo's OWN branch
+#   protection settings (not by anything in this file):
+#     - On `main`:    mark this check REQUIRED in branch protection — merge
+#                     is physically blocked while a critical alert is open.
+#     - On `develop`: leave this check NOT required — it still shows as a
+#                     failing/red check (a visible warning) without blocking
+#                     the merge.
+# =============================================================================
+name: Critical Vulnerability Check
+run-name: vuln-check-${{ github.event.pull_request.number }}
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+# critical-vuln-gate.yml's own job requests these two scopes -- a caller can
+# only narrow permissions for a nested reusable-workflow job, never widen
+# them, so these must be granted here or the whole file fails to parse.
+permissions:
+  contents: write
+  security-events: read
+
+jobs:
+  vuln-gate:
+    uses: simplify9/.github/.github/workflows/critical-vuln-gate.yml@main
+    secrets:
+      dependabot-alerts-token: ${{ secrets.DEPENDABOT_ALERTS_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,61 @@
+# =============================================================================
+# Dependabot Auto-Merge — Caller template
+# =============================================================================
+# USAGE:
+#   Copy this file to your repo at .github/workflows/dependabot-auto-merge.yml.
+#   No REPLACE values needed.
+#
+# WHAT IT DOES:
+#   Auto-merges a Dependabot PR ONLY when ALL of the following hold:
+#     - The PR author is dependabot[bot]
+#     - The update is a semver PATCH bump (never minor/major)
+#     - The ecosystem is npm, nuget, pub, bundler, or github-actions
+#       (NEVER docker — base image bumps always need manual review)
+#     - This repo currently has no open critical Dependabot alert (re-checked
+#       here explicitly — see workflow-templates/critical-vuln-check.yml's
+#       header for why this can't just `needs:` that file's job)
+#   "Auto-merge" here means GitHub's native auto-merge feature: it still
+#   waits for the repo's actual required status checks (build/test) to pass
+#   before merging — this workflow does not bypass those.
+# =============================================================================
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  pull-requests: write
+  contents: write
+  security-events: read
+
+jobs:
+  vuln-gate:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    uses: simplify9/.github/.github/workflows/critical-vuln-gate.yml@main
+    secrets:
+      dependabot-alerts-token: ${{ secrets.DEPENDABOT_ALERTS_TOKEN }}
+
+  auto-merge:
+    needs: vuln-gate
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for eligible patch bumps
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' &&
+          contains(fromJSON('["npm_and_yarn", "nuget", "pub", "bundler", "github_actions"]'), steps.metadata.outputs.package-ecosystem)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          set -euo pipefail
+          echo "::notice title=🤖 [AUTO-MERGE] Enabling auto-merge::${PR_URL} — patch-level ${{ steps.metadata.outputs.package-ecosystem }} bump, vuln gate passed"
+          gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Adds `.github/dependabot.yml` (category: `nuget-api`, target-branch: `main`), `.github/workflows/critical-vuln-check.yml`, and `.github/workflows/dependabot-auto-merge.yml` as part of the org-wide Dependabot rollout.