### PR TITLE
Kill child process on CommandTimeout to prevent stale-result mix-ups

### DIFF
--- a/SW.Serverless/Services/ServerlessService.cs
+++ b/SW.Serverless/Services/ServerlessService.cs
@@ -173,6 +173,25 @@ namespace SW.Serverless
         {
             invocationTimeoutTimer.Dispose();
             trySetTrySetExceptionMethod.Invoke(taskCompletionSource, new object[] { new TimeoutException() });
+
+            // The process is reused for multiple sequential commands on the same invocation
+            // (e.g. CreateShipment followed by GetLogs in a finally block). If we leave a
+            // timed-out process running, its eventual late output is delivered to whichever
+            // taskCompletionSource is current by then - a later, unrelated invocation - and
+            // silently resolves it with the wrong (stale) result instead of its own. Killing
+            // the process here removes that possibility entirely: no further output can ever
+            // arrive, and the next InvokeAsync on this instance fails fast via the
+            // "process not started or terminated" guard instead of hanging or being
+            // mis-resolved.
+            try
+            {
+                if (processStarted && !process.HasExited)
+                    process.Kill();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Failed to kill timed-out adapter process.");
+            }
         }
 
         void ErrorDataReceived(object sender, DataReceivedEventArgs args)

--- a/SW.Serverless/Services/ServerlessService.cs
+++ b/SW.Serverless/Services/ServerlessService.cs
@@ -30,6 +30,7 @@ namespace SW.Serverless
         private MethodInfo trySetTrySetExceptionMethod;
         private Timer invocationTimeoutTimer;
         private bool processStarted;
+        private volatile bool timedOut;
         private ILogger adapterLogger;
         private readonly ICloudFilesService cloudFilesService; 
         public ServerlessService(ServerlessOptions serverlessOptions, IMemoryCache memoryCache, ILoggerFactory loggerFactory, IServiceProvider serviceProvider, ICloudFilesService cloudFilesService)
@@ -141,7 +142,7 @@ namespace SW.Serverless
                 throw new ArgumentException("Invalid name.", nameof(command));
             }
 
-            if (!processStarted || process.HasExited)
+            if (!processStarted || process.HasExited || timedOut)
                 throw new Exception("Process not started or terminated.");
 
             taskCompletionSource = new TaskCompletionSource<TResult>();
@@ -172,17 +173,22 @@ namespace SW.Serverless
         void InvocationTimeoutTimerCallback(object state)
         {
             invocationTimeoutTimer.Dispose();
-            trySetTrySetExceptionMethod.Invoke(taskCompletionSource, new object[] { new TimeoutException() });
 
             // The process is reused for multiple sequential commands on the same invocation
             // (e.g. CreateShipment followed by GetLogs in a finally block). If we leave a
             // timed-out process running, its eventual late output is delivered to whichever
             // taskCompletionSource is current by then - a later, unrelated invocation - and
-            // silently resolves it with the wrong (stale) result instead of its own. Killing
-            // the process here removes that possibility entirely: no further output can ever
-            // arrive, and the next InvokeAsync on this instance fails fast via the
-            // "process not started or terminated" guard instead of hanging or being
-            // mis-resolved.
+            // silently resolves it with the wrong (stale) result instead of its own.
+            //
+            // Order matters here: kill (and mark this instance permanently dead) BEFORE
+            // completing the caller's Task. Completing the Task first would let the awaiter's
+            // continuation - e.g. that same finally-block GetLogs follow-up - start a new
+            // InvokeAsync and overwrite taskCompletionSource while the old process is still
+            // alive, racing the kill below. Killing first, and sticking `timedOut` regardless
+            // of whether Kill() itself throws, guarantees no further output can ever arrive and
+            // that the next InvokeAsync on this instance fails fast via the "process not
+            // started or terminated" guard instead of hanging or being mis-resolved.
+            timedOut = true;
             try
             {
                 if (processStarted && !process.HasExited)
@@ -191,6 +197,10 @@ namespace SW.Serverless
             catch (Exception ex)
             {
                 logger.LogWarning(ex, "Failed to kill timed-out adapter process.");
+            }
+            finally
+            {
+                trySetTrySetExceptionMethod.Invoke(taskCompletionSource, new object[] { new TimeoutException() });
             }
         }
 


### PR DESCRIPTION
## Summary
Fixes an un-correlated-`TaskCompletionSource` hazard, root-caused today against a live production hang.

`taskCompletionSource` / its reflection helpers / `invocationTimeoutTimer` are single mutable fields on `ServerlessService`, reused across sequential commands invoked on the same child process (e.g. a create-shipment command followed by a log-fetch command, chained in a `finally`). If a command times out, the old code only faulted the caller's `Task` — it never stops the underlying process. That process can then:
- emit its late result *after* a subsequent invocation has already overwritten `taskCompletionSource`, silently resolving the wrong invocation with stale data, or
- never emit anything at all (deadlock/hang), leaving the *next* invocation's own timer as the only thing that can ever unblock the caller — and if that one also doesn't fire cleanly for whatever reason, the caller hangs with **no logged error at all**.

## Production evidence
A consumer invocation for a create-shipment call sat **unacknowledged in its message queue for 11+ minutes**, well past both the 30s `CommandTimeout` and the 300s `IdleTimeout`, with **zero log lines** anywhere in the call chain. A manual retry through a separate code path (fresh invocation, unaffected by the wedged one) succeeded immediately and, interestingly, appears to have also resolved the original stuck message — consistent with a stale/orphaned completion rather than a genuine downstream failure.

## Fix
On `CommandTimeout`, kill the child process immediately (best-effort, logged on failure) in addition to faulting the current TCS. This guarantees:
- no further output can ever arrive to mis-resolve a later invocation on the same instance, and
- the next `InvokeAsync` on this instance fails fast via the existing `"Process not started or terminated."` guard instead of hanging or silently resolving to stale data.

## Test plan
- [x] `dotnet build SW.Serverless.sln -c Release` — 0 errors, no new warnings.
- [x] `dotnet test SW.Serverless.UnitTests` — same 7/7 pre-existing failures with and without this change (missing Azure CloudFiles test config, unrelated to this fix — confirmed via git stash/git stash pop comparison).
- [x] Touches only `ServerlessService.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
