### PR TITLE
fix: publish SimplyWorks.Serverless.Contract

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Pack and Push NuGet Packages
         uses: simplify9/.github/.github/actions/dotnet-pack-push@main
         with:
-          projects: "SW.Serverless/SW.Serverless.csproj SW.Serverless.Sdk/SW.Serverless.Sdk.csproj"
+          # Contract FIRST: both of the others depend on it, and publishing them without it
+          # produces packages whose dependency cannot resolve — which is what 8.1.13 shipped as.
+          projects: "SW.Serverless.Contract/SW.Serverless.Contract.csproj SW.Serverless/SW.Serverless.csproj SW.Serverless.Sdk/SW.Serverless.Sdk.csproj"
           configuration: "Release"
           version: ${{ steps.semver.outputs.version }}
           api-key: ${{ secrets.SWNUGETKEY }}


### PR DESCRIPTION
**8.1.13 is broken on nuget.org and needs a follow-up publish.**

`SimplyWorks.Serverless.Sdk 8.1.13` declares:

```xml
<dependency id="SimplyWorks.Serverless.Contract" version="8.1.13" />
```

but `simplyworks.serverless.contract` returns **404** — only two of the three packages were published. Restoring the Sdk or the runtime at 8.1.13 fails to resolve, which is worse than the version being absent, because the package looks available.

## Cause

The pack-push step enumerates projects explicitly:

```yaml
projects: "SW.Serverless/SW.Serverless.csproj SW.Serverless.Sdk/SW.Serverless.Sdk.csproj"
```

`SW.Serverless.Contract` was introduced as a new package in #108 and never added. The #108 description flagged this exact risk — *"`SimplyWorks.Serverless.Contract` is a new package. If the publish workflow enumerates projects explicitly rather than packing the solution, it needs adding"* — and it wasn't acted on.

## Fix

Contract is added **first**, since both other packages depend on it.

Verified locally with `dotnet pack`: the package builds with the correct id and its own dependencies (`Google.Protobuf`, `Grpc.Core.Api`) and no others.

## After merging

NuGet versions are immutable, so 8.1.13 cannot be repaired. The next publish produces a complete set. **Consider unlisting `SimplyWorks.Serverless` and `SimplyWorks.Serverless.Sdk` 8.1.13** so nobody resolves a broken pair in the meantime — Traxis Gateway would hit it on any bump.