### PR TITLE
Fix the CodeRabbit findings from #109

### DIFF
--- a/.junie/mcp/mcp.json
+++ b/.junie/mcp/mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "UnoApp": {
+      "command": "dotnet",
+      "args": [
+        "dnx",
+        "-y",
+        "uno.devserver",
+        "--mcp-app"
+      ]
+    },
+    "UnoDocs": {
+      "url": "https://mcp.platform.uno/v1"
+    }
+  }
+}

--- a/.junie/mcp/mcp.json.bak
+++ b/.junie/mcp/mcp.json.bak
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "UnoApp": {
+      "command": "dotnet",
+      "args": [
+        "dnx",
+        "-y",
+        "uno.devserver",
+        "--mcp-app"
+      ]
+    }
+  }
+}

--- a/SW.Serverless.SampleWeb/CarrierSim/CarrierService.cs
+++ b/SW.Serverless.SampleWeb/CarrierSim/CarrierService.cs
@@ -19,6 +19,11 @@ namespace SW.Serverless.SampleWeb.CarrierSim
     {
         // gRPC services are resolved per call, so instance state would vanish between them.
         static readonly ConcurrentDictionary<string, ShipmentRecord> shipments = new();
+
+        // Reference -> tracking number. Real carriers offer exactly this so a client that retries
+        // a timed-out create does not end up with two shipments; without it, no caller can safely
+        // retry CreateShipment at all.
+        static readonly ConcurrentDictionary<string, ShipmentRecord> byReference = new();
         readonly ILogger<CarrierService> logger;
 
         public CarrierService(ILogger<CarrierService> logger) => this.logger = logger;
@@ -50,6 +55,16 @@ namespace SW.Serverless.SampleWeb.CarrierSim
                     ErrorMessage = "At least one parcel is required."
                 };
 
+            var invalid = request.Parcels.FirstOrDefault(
+                p => double.IsNaN(p.WeightKg) || double.IsInfinity(p.WeightKg) || p.WeightKg <= 0);
+            if (invalid != null)
+                return new CreateShipmentReply
+                {
+                    Accepted = false,
+                    ErrorCode = "INVALID_WEIGHT",
+                    ErrorMessage = $"{invalid.WeightKg} kg is not a usable parcel weight."
+                };
+
             var overweight = request.Parcels.FirstOrDefault(p => p.WeightKg > 31.5);
             if (overweight != null)
                 return new CreateShipmentReply
@@ -59,15 +74,46 @@ namespace SW.Serverless.SampleWeb.CarrierSim
                     ErrorMessage = $"{overweight.WeightKg} kg exceeds the 31.5 kg limit for this service."
                 };
 
-            var tracking = $"SW{Random.Shared.NextInt64(100000000, 999999999)}";
             var price = Math.Round(4.50 + request.Parcels.Sum(p => p.WeightKg) * 0.85, 2);
 
-            shipments[tracking] = new ShipmentRecord
+            var record = new ShipmentRecord
             {
                 Reference = request.Reference,
                 CreatedOn = DateTimeOffset.UtcNow,
                 Destination = request.Recipient?.City ?? "unknown"
             };
+
+            // A repeat of a reference we already booked returns the original shipment rather than
+            // creating a second one. This is what makes the adapter's retry safe.
+            if (!string.IsNullOrWhiteSpace(request.Reference))
+            {
+                var winner = byReference.GetOrAdd(request.Reference, record);
+                if (!ReferenceEquals(winner, record))
+                {
+                    logger.LogInformation("Carrier replayed {Reference} as {Tracking}.",
+                        request.Reference, winner.TrackingNumber);
+                    return new CreateShipmentReply
+                    {
+                        Accepted = true,
+                        TrackingNumber = winner.TrackingNumber,
+                        LabelUrl = $"https://carrier.test/labels/{winner.TrackingNumber}.pdf",
+                        Price = winner.Price,
+                        Currency = "EUR"
+                    };
+                }
+            }
+
+            // TryAdd rather than the indexer: a repeated random number would otherwise replace an
+            // existing shipment, and tracking and cancellation would then act on the wrong one.
+            string tracking;
+            while (true)
+            {
+                tracking = $"SW{Random.Shared.NextInt64(100000000, 999999999)}";
+                if (shipments.TryAdd(tracking, record)) break;
+            }
+
+            record.TrackingNumber = tracking;
+            record.Price = price;
 
             logger.LogInformation("Carrier accepted {Reference} as {Tracking} for {Price} EUR.",
                 request.Reference, tracking, price);
@@ -146,6 +192,8 @@ namespace SW.Serverless.SampleWeb.CarrierSim
             public string Reference;
             public DateTimeOffset CreatedOn;
             public string Destination;
+            public string TrackingNumber;
+            public double Price;
         }
     }
 }

--- a/SW.Serverless.SampleWeb/Components/Pages/AdapterDashboard.razor
+++ b/SW.Serverless.SampleWeb/Components/Pages/AdapterDashboard.razor
@@ -6,6 +6,15 @@
 @inject DemoBootstrapper Bootstrapper
 
 <h1>Adapters</h1>
+
+<div class="banner warn">
+    <strong>Unauthenticated developer tool.</strong> Every control on this page acts without an
+    identity check: commands reach adapters, <em>Kill</em> ends process trees, and the carrier
+    simulator's shared state can be mutated by anyone who can reach the port. Run it on loopback
+    only. Ported into a real host, these controls need an operator policy enforced at each one —
+    the sample leaves that out so the observability it is demonstrating stays legible.
+</div>
+
 <p class="lede">
     Every figure below comes from one of two independent sources. <strong>Host-observed</strong>
     (memory, CPU, threads, restarts) needs no cooperation from the adapter, so it still works when
@@ -270,11 +279,18 @@
 
     async Task Drain(InstanceHealth h)
     {
-        var instance = Host.Get(h.AdapterId, h.InstanceKey);
-        if (instance is null) return;
-        await instance.SetLogLevelAsync(Microsoft.Extensions.Logging.LogLevel.Information);
-        results[Id(h)] = "Drain requested via the supervisor's soft path — the adapter stops "
-                       + "fetching, finishes what is in flight, then exits. A hard kill cannot do that.";
+        // The soft path: StopAsync(drain: true) is what tells the adapter to stop fetching and
+        // finish what is in flight. Anything else here would be a button that only claims to drain.
+        try
+        {
+            await Host.StopAsync(h.AdapterId, h.InstanceKey, drain: true);
+            results[Id(h)] = "Drain requested via the supervisor's soft path — the adapter stopped "
+                           + "fetching, finished what was in flight, then exited. A hard kill cannot do that.";
+        }
+        catch (Exception ex)
+        {
+            results[Id(h)] = $"ERROR  {ex.Message}";
+        }
     }
 
     async Task Invoke(InstanceHealth h, string command, string payload = null)

--- a/SW.Serverless.SampleWeb/Components/Spark.razor
+++ b/SW.Serverless.SampleWeb/Components/Spark.razor
@@ -1,3 +1,4 @@
+@using System.Globalization
 @* Ten one-second buckets of event throughput. Inline SVG — no charting library needed. *@
 
 <svg class="spark" viewBox="0 0 100 24" preserveAspectRatio="none" role="img"
@@ -5,8 +6,9 @@
     @for (var i = 0; i < bars.Length; i++)
     {
         var height = max == 0 ? 0.5 : Math.Max(0.5, bars[i] / (double)max * 22);
-        <rect x="@(i * 10 + 1)" y="@(23 - height).ToString("0.##")"
-              width="8" height="@height.ToString("0.##")" rx="1" fill="currentColor" />
+        @* SVG attributes are not culture-aware: a comma decimal separator makes the rect vanish. *@
+        <rect x="@(i * 10 + 1)" y="@Svg(23 - height)"
+              width="8" height="@Svg(height)" rx="1" fill="currentColor" />
     }
 </svg>
 
@@ -15,4 +17,6 @@
 
     int[] bars => Values is { Length: > 0 } ? Values : new int[10];
     int max => bars.Length == 0 ? 0 : bars.Max();
+
+    static string Svg(double value) => value.ToString("0.##", CultureInfo.InvariantCulture);
 }

--- a/SW.Serverless.SampleWeb/Telemetry/DashboardEventSink.cs
+++ b/SW.Serverless.SampleWeb/Telemetry/DashboardEventSink.cs
@@ -16,7 +16,9 @@ namespace SW.Serverless.SampleWeb.Telemetry
     {
         readonly DashboardState state;
         readonly ILogger<DashboardEventSink> logger;
-        readonly ConcurrentDictionary<string, string> seen = new();
+        // Bounded by age, not unbounded for the process lifetime: ten minutes comfortably covers
+        // the redelivery horizon of everything the samples connect to.
+        readonly DedupeWindow seen = new(TimeSpan.FromMinutes(10));
 
         long sequence;
 
@@ -30,11 +32,15 @@ namespace SW.Serverless.SampleWeb.Telemetry
         {
             state.Tick();
 
-            var body = Encoding.UTF8.GetString(e.Payload ?? Array.Empty<byte>());
-            var preview = body.Length > 200 ? body[..200] + "..." : body;
+            var preview = Preview(e.Payload, 200);
 
-            // At-least-once delivery is not optional, so neither is this.
-            if (!string.IsNullOrEmpty(e.DedupeKey) && seen.TryGetValue(e.DedupeKey, out var already))
+            var reference = $"xch-{Interlocked.Increment(ref sequence):00000}";
+            var keyed = !string.IsNullOrEmpty(e.DedupeKey);
+
+            // At-least-once delivery is not optional, so neither is this. The claim and the lookup
+            // have to be one step: two concurrent redeliveries of the same message must not both
+            // pass a read-only check and both be accepted.
+            if (keyed && !seen.TryClaim(e.DedupeKey, reference, out var already))
             {
                 Interlocked.Increment(ref state.Duplicates);
                 state.Events.Add(new EventRow(DateTimeOffset.Now, e.AdapterId, e.Endpoint,
@@ -46,6 +52,10 @@ namespace SW.Serverless.SampleWeb.Telemetry
             // Failure injection: prove the adapter leaves the message for redelivery.
             if (Interlocked.Decrement(ref state.RejectNext) >= 0)
             {
+                // The event goes back to the source, so give up the claim — its redelivery is a
+                // fresh attempt and must not be swallowed as a duplicate.
+                if (keyed) seen.Release(e.DedupeKey);
+
                 Interlocked.Increment(ref state.Rejected);
                 state.Events.Add(new EventRow(DateTimeOffset.Now, e.AdapterId, e.Endpoint,
                     e.DedupeKey, e.Payload?.Length ?? 0, preview, "rejected", null));
@@ -53,15 +63,28 @@ namespace SW.Serverless.SampleWeb.Telemetry
             }
             Interlocked.Exchange(ref state.RejectNext, Math.Max(0, state.RejectNext));
 
-            var reference = $"xch-{Interlocked.Increment(ref sequence):00000}";
-            if (!string.IsNullOrEmpty(e.DedupeKey)) seen[e.DedupeKey] = reference;
-
             Interlocked.Increment(ref state.Accepted);
             if (!state.FeedPaused)
                 state.Events.Add(new EventRow(DateTimeOffset.Now, e.AdapterId, e.Endpoint,
                     e.DedupeKey, e.Payload?.Length ?? 0, preview, "accepted", reference));
 
             return Task.FromResult(EventOutcome.Ok(reference));
+        }
+
+        /// <summary>
+        /// Decodes only as much as the preview can show. Decoding the whole payload first would
+        /// allocate a string the size of every inbound event just to throw most of it away — and a
+        /// single large event could take the host down.
+        /// </summary>
+        static string Preview(byte[] payload, int chars)
+        {
+            if (payload is not { Length: > 0 }) return "";
+
+            var bytes = Math.Min(payload.Length, chars * 4);      // UTF-8 is at most 4 bytes a char
+            var text = Encoding.UTF8.GetString(payload, 0, bytes);
+            if (text.Length > chars) text = text[..chars];
+
+            return text.Length < chars && bytes == payload.Length ? text : text + "...";
         }
     }
 }

--- a/SW.Serverless.SampleWeb/Telemetry/DashboardState.cs
+++ b/SW.Serverless.SampleWeb/Telemetry/DashboardState.cs
@@ -51,10 +51,16 @@ namespace SW.Serverless.SampleWeb.Telemetry
         {
             get
             {
+                var now = DateTimeOffset.UtcNow;
                 lock (rateGate)
                 {
+                    // Tick is not the only reader: without expiring here, a feed that stops still
+                    // reports a rate from stale timestamps long after the histogram has emptied.
+                    while (recent.Count > 0 && now - recent.Peek() > TimeSpan.FromSeconds(10))
+                        recent.Dequeue();
+
                     if (recent.Count < 2) return 0;
-                    var span = (DateTimeOffset.UtcNow - recent.Peek()).TotalSeconds;
+                    var span = (now - recent.Peek()).TotalSeconds;
                     return span <= 0 ? 0 : Math.Round(recent.Count / span, 1);
                 }
             }

--- a/SW.Serverless.SampleWeb/Telemetry/DedupeWindow.cs
+++ b/SW.Serverless.SampleWeb/Telemetry/DedupeWindow.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+
+namespace SW.Serverless.SampleWeb.Telemetry
+{
+    /// <summary>
+    /// A dedupe table with a retention window, which is the shape a real one has too. Bitween keeps
+    /// this in the database with a pruning job; a sample keeps it in memory — but not for ever, or a
+    /// long-lived host with a steady stream of distinct keys simply grows until it dies.
+    ///
+    /// The window has to cover the source's redelivery horizon. Evicting sooner than that lets a
+    /// late redelivery through as if it were new, which is why this expires by age rather than by
+    /// capacity.
+    /// </summary>
+    public sealed class DedupeWindow
+    {
+        readonly ConcurrentDictionary<string, Entry> entries = new();
+        readonly TimeSpan retention;
+        long nextSweepTicks;
+
+        public DedupeWindow(TimeSpan retention) => this.retention = retention;
+
+        public int Count => entries.Count;
+
+        /// <summary>
+        /// Claims <paramref name="key"/> atomically. Returns false when it was already claimed, and
+        /// hands back the reference the first claimant recorded. Check-then-act would let two
+        /// concurrent redeliveries of one message both be accepted.
+        /// </summary>
+        public bool TryClaim(string key, string reference, out string existing)
+        {
+            Sweep();
+
+            var mine = new Entry(reference, DateTimeOffset.UtcNow);
+            var winner = entries.GetOrAdd(key, mine);
+
+            if (ReferenceEquals(winner, mine)) { existing = reference; return true; }
+
+            // An entry older than the window is a leftover the sweep has not reached yet; treat it
+            // as expired rather than as a duplicate.
+            if (DateTimeOffset.UtcNow - winner.At > retention &&
+                entries.TryUpdate(key, mine, winner))
+            {
+                existing = reference;
+                return true;
+            }
+
+            existing = winner.Reference;
+            return false;
+        }
+
+        /// <summary>
+        /// Releases a claim. Used when the event was rejected and goes back to the source: its
+        /// redelivery is a fresh attempt, not a duplicate.
+        /// </summary>
+        public void Release(string key) => entries.TryRemove(key, out _);
+
+        void Sweep()
+        {
+            var now = DateTimeOffset.UtcNow;
+            var due = Interlocked.Read(ref nextSweepTicks);
+            if (now.UtcTicks < due) return;
+            if (Interlocked.CompareExchange(ref nextSweepTicks,
+                    now.AddSeconds(30).UtcTicks, due) != due) return;
+
+            foreach (var pair in entries)
+                if (now - pair.Value.At > retention)
+                    entries.TryRemove(pair);
+        }
+
+        sealed class Entry
+        {
+            public readonly string Reference;
+            public readonly DateTimeOffset At;
+            public Entry(string reference, DateTimeOffset at) { Reference = reference; At = at; }
+        }
+    }
+}

--- a/SW.Serverless.SampleWeb/wwwroot/app.css
+++ b/SW.Serverless.SampleWeb/wwwroot/app.css
@@ -3,7 +3,7 @@
   --ink:#16202b; --ink2:#4d6072; --dim:#7d91a3; --rule:#dbe3ea;
   --accent:#0d6a72; --ok:#1f7a52; --ok-bg:#dcefe4; --warn:#8a5a12; --warn-bg:#faf0da;
   --bad:#9c3328; --bad-bg:#f8e2df; --muted-bg:#e7edf1;
-  --mono:"SFMono-Regular",Menlo,Consolas,monospace;
+  --mono:"SFMono-Regular","Menlo","Consolas",monospace;
 }
 @media (prefers-color-scheme:dark){
   :root{
@@ -97,7 +97,7 @@ input.wide{flex:1;min-width:230px}
 
 pre.result,pre.diag{font:12px/1.5 var(--mono);background:var(--surface2);border:1px solid var(--rule);
   border-radius:5px;padding:11px 13px;margin:13px 0 0;overflow-x:auto;white-space:pre-wrap;
-  word-break:break-word;max-height:280px}
+  overflow-wrap:anywhere;max-height:280px}
 pre.result.bad{border-color:var(--bad);color:var(--bad)}
 pre.diag{color:var(--ink2);max-height:220px}
 details{margin-top:14px}

--- a/SW.Serverless.Samples.Carrier/CarrierHandler.cs
+++ b/SW.Serverless.Samples.Carrier/CarrierHandler.cs
@@ -40,6 +40,9 @@ namespace SW.Serverless.Samples.Carrier
         string lastError;
         volatile string state = "Starting";
 
+        // Stop is terminal: once it has run, no in-flight call may report the adapter healthy again.
+        volatile bool stopped;
+
         public CarrierHandler(CarrierContract.Carrier.CarrierClient carrier,
             IOptions<CarrierOptions> options, CallLog callLog, ILogger<CarrierHandler> logger)
         {
@@ -77,6 +80,7 @@ namespace SW.Serverless.Samples.Carrier
 
         public Task StopAsync(CancellationToken cancellationToken)
         {
+            stopped = true;
             state = "Stopped";
             logger.LogInformation("Carrier adapter stopping after {Created} shipments.", created);
             return Task.CompletedTask;
@@ -144,10 +148,14 @@ namespace SW.Serverless.Samples.Carrier
                 HeightCm = p.Height
             }));
 
+            // Retrying a create is only safe because the carrier deduplicates on our reference and
+            // replays the original shipment. With no reference there is nothing to deduplicate on,
+            // so a retry after a timeout could book the same parcel twice — do not retry then.
             var reply = await CallAsync(nameof(CreateShipment),
                 token => carrier.CreateShipmentAsync(upstream,
                     deadline: DateTime.UtcNow.AddSeconds(options.TimeoutSeconds),
-                    cancellationToken: token));
+                    cancellationToken: token),
+                idempotent: !string.IsNullOrWhiteSpace(upstream.Reference));
 
             if (reply == null)
                 return new ShipmentResult
@@ -259,7 +267,8 @@ namespace SW.Serverless.Samples.Carrier
         /// remember them — which is exactly what a base class does for the Traxis adapters.
         /// </summary>
         async Task<TReply> CallAsync<TReply>(string operation,
-            Func<CancellationToken, AsyncUnaryCall<TReply>> call) where TReply : class
+            Func<CancellationToken, AsyncUnaryCall<TReply>> call, bool idempotent = true)
+            where TReply : class
         {
             var clock = Stopwatch.StartNew();
 
@@ -271,6 +280,12 @@ namespace SW.Serverless.Samples.Carrier
 
                     clock.Stop();
                     lastCallOn = DateTimeOffset.UtcNow;
+
+                    // A failed attempt may have parked the adapter in "Disconnected"; a success
+                    // clears that. Shutdown wins, so a call landing after StopAsync cannot
+                    // resurrect the adapter's reported state.
+                    if (!stopped) state = "Connected";
+
                     callLog.Record(operation, clock.Elapsed, true,
                         attempt > 1 ? $"succeeded on attempt {attempt}" : null);
 
@@ -279,13 +294,15 @@ namespace SW.Serverless.Samples.Carrier
 
                     return reply;
                 }
-                catch (RpcException ex) when (Transient(ex) && attempt < options.MaxAttempts)
+                catch (RpcException ex) when (idempotent && Transient(ex) && attempt < options.MaxAttempts)
                 {
                     retries++;
                     logger.LogWarning("{Operation} failed with {Status}; retrying ({Attempt}/{Max}).",
                         operation, ex.StatusCode, attempt, options.MaxAttempts);
 
-                    await Task.Delay(options.RetryDelayMs * attempt);
+                    // Without the stop token the loop sits out the whole delay during shutdown and
+                    // then makes one more attempt with an already-cancelled token.
+                    await Task.Delay(options.RetryDelayMs * attempt, context?.Stopping ?? CancellationToken.None);
                 }
                 catch (Exception ex)
                 {

--- a/SW.Serverless.Samples.Carrier/Program.cs
+++ b/SW.Serverless.Samples.Carrier/Program.cs
@@ -17,8 +17,15 @@ namespace SW.Serverless.Samples.Carrier
                 // A pooled, long-lived HTTP/2 channel. Under the classic lifecycle this would be
                 // dialled and thrown away on every single call; here it is opened once and reused
                 // for the life of the adapter, which is most of where the latency saving comes from.
-                services.AddGrpcClient<CarrierContract.Carrier.CarrierClient>(o =>
-                    o.Address = new Uri(configuration["BaseUrl"] ?? "http://localhost:5200"));
+                // Set BaseUrl to an https endpoint against a real carrier: account number, API key
+                // and address data all cross this channel, and h2c sends them in the clear. The
+                // plain-http default exists only so the bundled local simulator works out of the box.
+                var baseUrl = new Uri(configuration["BaseUrl"] ?? "http://localhost:5200");
+                if (!baseUrl.IsLoopback && baseUrl.Scheme != Uri.UriSchemeHttps)
+                    Console.Error.WriteLine(
+                        $"WARNING: carrier BaseUrl '{baseUrl}' is not TLS; credentials would be sent in the clear.");
+
+                services.AddGrpcClient<CarrierContract.Carrier.CarrierClient>(o => o.Address = baseUrl);
             })
             .Build<CarrierHandler>()
             .RunResidentAsync();

--- a/SW.Serverless.Samples.Host/ConsoleEventSink.cs
+++ b/SW.Serverless.Samples.Host/ConsoleEventSink.cs
@@ -21,8 +21,7 @@ namespace SW.Serverless.Samples.Host
 
         public Task<EventOutcome> OnEventAsync(InboundEvent e, CancellationToken cancellationToken)
         {
-            var body = Encoding.UTF8.GetString(e.Payload);
-            if (body.Length > 120) body = body[..120] + "...";
+            var body = Preview(e.Payload, 120);
 
             // Reject anything already seen: at-least-once delivery means this is not optional.
             if (!Seen.TryAdd(e.DedupeKey))
@@ -39,11 +38,60 @@ namespace SW.Serverless.Samples.Host
             return Task.FromResult(EventOutcome.Ok(reference));
         }
 
+        /// <summary>
+        /// Decodes only what the preview shows. Decoding the whole payload first allocates a string
+        /// the size of every inbound event, and one large event could then exhaust the host.
+        /// </summary>
+        static string Preview(byte[] payload, int chars)
+        {
+            if (payload is not { Length: > 0 }) return "";
+
+            var bytes = Math.Min(payload.Length, chars * 4);      // UTF-8 is at most 4 bytes a char
+            var text = Encoding.UTF8.GetString(payload, 0, bytes);
+            if (text.Length > chars) text = text[..chars];
+
+            return text.Length < chars && bytes == payload.Length ? text : text + "...";
+        }
+
+        /// <summary>
+        /// Keys expire rather than accumulating for the process lifetime — this host runs
+        /// indefinitely, and a steady stream of distinct keys would otherwise grow until it dies.
+        /// The window has to cover the source's redelivery horizon; a real host would keep this in
+        /// a database with a pruning job, which is exactly what Bitween does.
+        /// </summary>
         static class Seen
         {
-            static readonly System.Collections.Concurrent.ConcurrentDictionary<string, byte> keys = new();
-            public static bool TryAdd(string key) =>
-                string.IsNullOrEmpty(key) || keys.TryAdd(key, 0);
+            static readonly TimeSpan Retention = TimeSpan.FromMinutes(10);
+            static readonly System.Collections.Concurrent.ConcurrentDictionary<string, DateTimeOffset> keys = new();
+            static long nextSweepTicks;
+
+            public static bool TryAdd(string key)
+            {
+                if (string.IsNullOrEmpty(key)) return true;
+
+                Sweep();
+                var now = DateTimeOffset.UtcNow;
+
+                if (keys.TryAdd(key, now)) return true;
+
+                // An entry the sweep has not reached yet is expired, not a duplicate.
+                return keys.TryGetValue(key, out var at)
+                       && now - at > Retention
+                       && keys.TryUpdate(key, now, at);
+            }
+
+            static void Sweep()
+            {
+                var now = DateTimeOffset.UtcNow;
+                var due = Interlocked.Read(ref nextSweepTicks);
+                if (now.UtcTicks < due) return;
+                if (Interlocked.CompareExchange(ref nextSweepTicks,
+                        now.AddSeconds(30).UtcTicks, due) != due) return;
+
+                foreach (var pair in keys)
+                    if (now - pair.Value > Retention)
+                        keys.TryRemove(pair);
+            }
         }
     }
 }

--- a/SW.Serverless.Samples.LargeFiles/LargeFileHandler.cs
+++ b/SW.Serverless.Samples.LargeFiles/LargeFileHandler.cs
@@ -164,7 +164,12 @@ namespace SW.Serverless.Samples.LargeFiles
         {
             var name = Path.GetFileName(path);
 
-            try { using var _ = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read); }
+            // An exclusive open is the only handoff that actually proves the producer is finished:
+            // a writer holding the file with FileShare.Read would sail through a read-only probe and
+            // we would stream — and then archive — a partial file. Producers that cannot cooperate
+            // should write under a non-matching temporary name and rename it when complete; the
+            // rename is atomic, so the scan never sees a half-written file under the watched name.
+            try { using var _ = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.None); }
             catch (IOException) { return; }     // still being written; next poll
 
             currentFile = name;
@@ -174,6 +179,7 @@ namespace SW.Serverless.Samples.LargeFiles
             meter.Start();
 
             var accepted = true;
+            var completed = false;      // only a clean run through every chunk sets this
 
             try
             {
@@ -233,6 +239,8 @@ namespace SW.Serverless.Samples.LargeFiles
                     if (options.ThrottleMsPerChunk > 0)
                         await Task.Delay(options.ThrottleMsPerChunk, ct);
                 }
+
+                completed = accepted;
             }
             catch (OperationCanceledException) { throw; }
             catch (Exception ex)
@@ -244,7 +252,9 @@ namespace SW.Serverless.Samples.LargeFiles
             }
             finally
             {
-                if (accepted)
+                // Cancellation mid-stream leaves `accepted` true but the file half-sent. Archiving
+                // on that would silently drop the remainder, so archive only on a completed run.
+                if (completed)
                 {
                     filesCompleted++;
                     logger.LogInformation(

--- a/SW.Serverless.Samples.RabbitMq/Consumer/ConsumerHandler.cs
+++ b/SW.Serverless.Samples.RabbitMq/Consumer/ConsumerHandler.cs
@@ -25,6 +25,12 @@ namespace SW.Serverless.Samples.RabbitMq.Consumer
     public class ConsumerHandler : RabbitAdapterBase
     {
         IModel channel;
+
+        // RabbitMQ.Client does not support concurrent application operations on one IModel, and
+        // deliveries are handled on the thread pool — so every application-initiated call on this
+        // channel goes through the gate, acks and nacks included.
+        readonly object channelGate = new();
+
         string consumerTag;
         string queueName;
         ushort prefetch = 16;
@@ -44,7 +50,16 @@ namespace SW.Serverless.Samples.RabbitMq.Consumer
 
             // Prefetch is per channel and is the broker-side half of backpressure. The host-side
             // half is the credit window on PublishAsync; size them together.
-            channel.BasicQos(0, prefetch, global: false);
+            lock (channelGate) channel.BasicQos(0, prefetch, global: false);
+
+            // Manage-only mode: declare the topology and expose the commands, but do not consume.
+            // The provider plan calls this declareMode, and it is how you inspect or purge a queue
+            // without a consumer quietly draining it out from under you.
+            if (Context.StartupValueOf("Consume") == "false")
+            {
+                Context.LogInformation($"Declared '{queueName}' without consuming (Consume=false).");
+                return;
+            }
 
             var consumer = new EventingBasicConsumer(channel);
             consumer.Received += OnReceived;
@@ -79,8 +94,11 @@ namespace SW.Serverless.Samples.RabbitMq.Consumer
 
         protected override void OnStopping()
         {
-            try { if (consumerTag != null) channel?.BasicCancel(consumerTag); } catch { }
-            try { channel?.Close(); channel?.Dispose(); } catch { }
+            lock (channelGate)
+            {
+                try { if (consumerTag != null) channel?.BasicCancel(consumerTag); } catch { }
+                try { channel?.Close(); channel?.Dispose(); } catch { }
+            }
         }
 
         void OnReceived(object sender, BasicDeliverEventArgs delivery)
@@ -108,11 +126,13 @@ namespace SW.Serverless.Samples.RabbitMq.Consumer
 
                 var result = await Context.PublishAsync(
                     delivery.Body,
-                    // The broker's message id is the natural dedupe key. Falling back to a
-                    // delivery tag would be wrong: tags are per channel and reset on reconnect.
+                    // The broker's message id is the natural key. There is no substitute: a body
+                    // hash would make two legitimately identical messages look like a redelivery
+                    // and silently drop the second, and delivery tags are per channel and reset on
+                    // reconnect. With no id we publish unkeyed and let the host see every delivery.
                     dedupeKey: delivery.BasicProperties?.MessageId is { Length: > 0 } id
                         ? $"rabbit:{ExchangeName}:{id}"
-                        : $"rabbit:{ExchangeName}:{Convert.ToHexString(System.Security.Cryptography.SHA256.HashData(delivery.Body.Span))[..32]}",
+                        : WarnUnkeyed(),
                     endpoint: queueName,
                     headers: headers,
                     contentType: delivery.BasicProperties?.ContentType ?? "application/octet-stream",
@@ -120,7 +140,7 @@ namespace SW.Serverless.Samples.RabbitMq.Consumer
 
                 if (result.Accepted)
                 {
-                    channel.BasicAck(delivery.DeliveryTag, multiple: false);
+                    lock (channelGate) channel.BasicAck(delivery.DeliveryTag, multiple: false);
                     Interlocked.Increment(ref acked);
                     lastMessageOn = DateTimeOffset.UtcNow;
 
@@ -131,22 +151,32 @@ namespace SW.Serverless.Samples.RabbitMq.Consumer
                 else
                 {
                     // Back onto the queue. The host said no, so this is a redelivery, not a loss.
-                    channel.BasicNack(delivery.DeliveryTag, multiple: false, requeue: true);
+                    lock (channelGate) channel.BasicNack(delivery.DeliveryTag, multiple: false, requeue: true);
                     Interlocked.Increment(ref nacked);
                     LastError = result.Error;
                 }
             }
             catch (OperationCanceledException)
             {
-                try { channel.BasicNack(delivery.DeliveryTag, false, requeue: true); } catch { }
+                try { lock (channelGate) channel.BasicNack(delivery.DeliveryTag, false, requeue: true); } catch { }
             }
             catch (Exception ex)
             {
                 Interlocked.Increment(ref failed);
                 LastError = ex.Message;
                 Context.LogError("Failed to hand a delivery to the host.", ex);
-                try { channel.BasicNack(delivery.DeliveryTag, false, requeue: true); } catch { }
+                try { lock (channelGate) channel.BasicNack(delivery.DeliveryTag, false, requeue: true); } catch { }
             }
+        }
+
+        long unkeyed;
+
+        string WarnUnkeyed()
+        {
+            if (Interlocked.Increment(ref unkeyed) == 1)
+                Context.LogWarning("A message arrived without a MessageId, so it cannot be " +
+                    "deduplicated. Publishers should set one.");
+            return null;
         }
 
         protected override object DeclareMore(IModel model)
@@ -221,14 +251,15 @@ namespace SW.Serverless.Samples.RabbitMq.Consumer
                 throw new ArgumentOutOfRangeException(nameof(value), "Expected 1..65535.");
 
             prefetch = (ushort)value;
-            channel.BasicQos(0, prefetch, global: false);
+            lock (channelGate) channel.BasicQos(0, prefetch, global: false);
             Context.LogInformation($"Prefetch changed to {prefetch} at runtime.");
             return Task.FromResult<object>(new { prefetch });
         }
 
         public Task<object> PurgeQueue()
         {
-            var purged = channel.QueuePurge(queueName);
+            uint purged;
+            lock (channelGate) purged = channel.QueuePurge(queueName);
             Context.LogWarning($"Purged {purged} messages from '{queueName}'.");
             return Task.FromResult<object>(new { purged });
         }

--- a/SW.Serverless.Samples.RabbitMq/RabbitAdapterBase.cs
+++ b/SW.Serverless.Samples.RabbitMq/RabbitAdapterBase.cs
@@ -62,18 +62,40 @@ namespace SW.Serverless.Samples.RabbitMq
 
         protected virtual void OnStarted() { }
 
-        protected static ConnectionFactory CreateConnectionFactory(IAdapterContext context) => new()
+        protected static ConnectionFactory CreateConnectionFactory(IAdapterContext context)
         {
-            HostName = context.StartupValueOf("Host") ?? "localhost",
-            Port = int.TryParse(context.StartupValueOf("Port"), out var port) ? port : 5672,
-            UserName = context.StartupValueOf("UserName") ?? "guest",
-            Password = context.StartupValueOf("Password") ?? "guest",
-            VirtualHost = context.StartupValueOf("VirtualHost") ?? "/",
+            // AMQP authenticates with PLAIN, so without TLS the broker password crosses the network
+            // in the clear. Off by default only because the test broker is a local container;
+            // set Tls=true (and Port=5671) for anything that is not localhost.
+            var tls = context.StartupValueOf("Tls") == "true";
+            var host = context.StartupValueOf("Host") ?? "localhost";
 
-            // The supervisor owns restart policy, so do not also run a hidden one in here.
-            AutomaticRecoveryEnabled = false,
-            RequestedConnectionTimeout = TimeSpan.FromSeconds(10)
-        };
+            var factory = new ConnectionFactory
+            {
+                HostName = host,
+                Port = int.TryParse(context.StartupValueOf("Port"), out var port) ? port : (tls ? 5671 : 5672),
+                UserName = context.StartupValueOf("UserName") ?? "guest",
+                Password = context.StartupValueOf("Password") ?? "guest",
+                VirtualHost = context.StartupValueOf("VirtualHost") ?? "/",
+
+                // The supervisor owns restart policy, so do not also run a hidden one in here.
+                AutomaticRecoveryEnabled = false,
+                RequestedConnectionTimeout = TimeSpan.FromSeconds(10)
+            };
+
+            if (tls)
+            {
+                factory.Ssl.Enabled = true;
+                factory.Ssl.ServerName = context.StartupValueOf("TlsServerName") ?? host;
+            }
+            else if (host != "localhost" && host != "127.0.0.1")
+            {
+                context.LogWarning($"Connecting to '{host}' without TLS — the broker password will " +
+                                   "cross the network in the clear. Set Tls=true.");
+            }
+
+            return factory;
+        }
 
         protected void DeclareExchange(IModel channel) =>
             channel.ExchangeDeclare(ExchangeName, ExchangeType, durable: false, autoDelete: false);

--- a/SW.Serverless.UnitTests/CarrierAdapterTests.cs
+++ b/SW.Serverless.UnitTests/CarrierAdapterTests.cs
@@ -1,6 +1,8 @@
 using Grpc.Core;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -33,22 +35,27 @@ namespace SW.Serverless.UnitTests
         static WebApplication carrier;
         static IHost host;
         static IResidentAdapterHost adapters;
-        static int port;
+        static string baseUrl;
 
         [ClassInitialize]
         public static async Task ClassInitialize(TestContext context)
         {
-            port = Random.Shared.Next(21000, 21900);
-
+            // Port 0 lets the OS hand out a free port and hold it for Kestrel. Picking a random
+            // number instead reserves nothing, so a parallel test or any local process can take it
+            // between the choice and the bind — an intermittent AddressAlreadyInUse.
             var builder = WebApplication.CreateBuilder();
             builder.Logging.ClearProviders();
             builder.WebHost.ConfigureKestrel(k =>
-                k.ListenLocalhost(port, o => o.Protocols = HttpProtocols.Http2));
+                k.Listen(System.Net.IPAddress.Loopback, 0, o => o.Protocols = HttpProtocols.Http2));
             builder.Services.AddGrpc();
 
             carrier = builder.Build();
             carrier.MapGrpcService<FakeCarrier>();
             await carrier.StartAsync();
+
+            baseUrl = carrier.Services.GetRequiredService<IServer>()
+                .Features.Get<IServerAddressesFeature>()!.Addresses.First()
+                .Replace("127.0.0.1", "localhost");
 
             host = Host.CreateDefaultBuilder()
                 .ConfigureLogging(l => l.ClearProviders())
@@ -106,7 +113,7 @@ namespace SW.Serverless.UnitTests
             InstanceKey = key,
             StartupValues =
             {
-                ["BaseUrl"] = $"http://localhost:{port}",
+                ["BaseUrl"] = baseUrl,
                 ["Account"] = "TEST-ACCT",
                 ["ApiKey"] = "not-a-real-secret",
                 ["MaxAttempts"] = "3",
@@ -131,7 +138,7 @@ namespace SW.Serverless.UnitTests
             var result = await instance.InvokeAsync<JObject>("TestConnection");
 
             Assert.IsTrue(result.Value<bool>("ok"));
-            Assert.AreEqual($"http://localhost:{port}", result.Value<string>("endpoint"));
+            Assert.AreEqual(baseUrl, result.Value<string>("endpoint"));
             Assert.AreEqual("fake-carrier/1.0", result.Value<string>("version"));
         }
 

--- a/SW.Serverless.UnitTests/LargeFileAdapterTests.cs
+++ b/SW.Serverless.UnitTests/LargeFileAdapterTests.cs
@@ -187,11 +187,18 @@ namespace SW.Serverless.UnitTests
         [TestMethod]
         public async Task Streaming_can_be_paused_and_resumed()
         {
-            var instance = await Start("pause");
+            // A heavier throttle so the transfer is still in flight when Pause lands. At 2 ms a
+            // chunk the whole file can finish before the poll below returns, and then the test is
+            // pausing nothing and waiting for acknowledgements that can never arrive.
+            var instance = await Start("pause", throttleMsPerChunk: 60);
 
             await instance.InvokeAsync<JObject>("GenerateTestFile", 8, timeoutSeconds: 60);
             await WaitFor(async () =>
-                (await instance.InvokeAsync<JObject>("GetProgress")).Value<int>("chunksAcked") > 2,
+                {
+                    var progress = await instance.InvokeAsync<JObject>("GetProgress");
+                    return progress.Value<int>("chunksAcked") > 2
+                           && progress.Value<string>("state") == "Streaming";
+                },
                 TimeSpan.FromSeconds(60), "streaming never started");
 
             var paused = await instance.InvokeAsync<JObject>("Pause");
@@ -213,7 +220,10 @@ namespace SW.Serverless.UnitTests
         [TestMethod]
         public async Task Progress_reaches_the_health_view_through_the_heartbeat()
         {
-            var instance = await Start("progress");
+            // Throttled so the transfer is still running when the heartbeat samples it. At full
+            // speed the file can complete between two heartbeats and progress never appears —
+            // the test would then be asserting on timing, not on the heartbeat.
+            var instance = await Start("progress", throttleMsPerChunk: 40);
             await instance.InvokeAsync<JObject>("GenerateTestFile", 16, timeoutSeconds: 90);
 
             await WaitFor(() => adapters.Describe()
@@ -232,7 +242,7 @@ namespace SW.Serverless.UnitTests
 
         static string RootFor(string key) => Path.Combine(root, key);
 
-        static Task<ResidentAdapterInstance> Start(string key)
+        static Task<ResidentAdapterInstance> Start(string key, int throttleMsPerChunk = 2)
         {
             Directory.CreateDirectory(RootFor(key));
             return adapters.StartExclusiveAsync(new AdapterSpec
@@ -245,7 +255,7 @@ namespace SW.Serverless.UnitTests
                     ["Pattern"] = "*.bin",
                     ["ChunkSizeKb"] = ChunkKb.ToString(),
                     ["PollSeconds"] = "1",
-                    ["ThrottleMsPerChunk"] = "2"
+                    ["ThrottleMsPerChunk"] = throttleMsPerChunk.ToString()
                 }
             });
         }

--- a/SW.Serverless.UnitTests/RabbitAdapterTests.cs
+++ b/SW.Serverless.UnitTests/RabbitAdapterTests.cs
@@ -287,10 +287,12 @@ namespace SW.Serverless.UnitTests
             var queue = "q.purge";
 
             // Consumer first so the queue and binding exist, then stop it so nothing drains.
+            // AutoDelete has to be off: the default deletes the queue the moment this consumer
+            // goes away, and the purge below would then be purging a brand new empty queue.
             await adapters.StartExclusiveAsync(new AdapterSpec
             {
                 AdapterId = ConsumerId, InstanceKey = "purge-in",
-                StartupValues = Common(exchange, queue)
+                StartupValues = Common(exchange, queue, autoDelete: false)
             });
             await adapters.StopAsync(ConsumerId, "purge-in", drain: false);
 
@@ -302,15 +304,25 @@ namespace SW.Serverless.UnitTests
             for (var i = 0; i < 5; i++)
                 await publisher.InvokeAsync<object>("PublishOne", $"{{\"n\":{i}}}");
 
-            // Re-attach only to purge and read depth.
+            // Re-attach only to purge and read depth. Consume=false matters: an actively consuming
+            // instance would ack the five messages away before the purge could see them.
+            var checkValues = Common(exchange, queue, autoDelete: false);
+            checkValues["Consume"] = "false";
+
             var consumer = await adapters.StartExclusiveAsync(new AdapterSpec
             {
                 AdapterId = ConsumerId, InstanceKey = "purge-check",
-                StartupValues = Common(exchange, queue)
+                StartupValues = checkValues
             });
+
+            // Wait for the publishes to land before purging, or the count proves nothing.
+            await WaitFor(async () => (await Stats(consumer)).Value<int?>("depth") >= 5,
+                TimeSpan.FromSeconds(15), "the published messages never reached the queue");
+
             var purged = await consumer.InvokeAsync<JObject>("PurgeQueue");
 
-            Assert.IsTrue(purged.Value<int>("purged") >= 0);
+            Assert.IsTrue(purged.Value<int>("purged") >= 5,
+                $"expected at least the 5 published messages to be purged, got {purged.Value<int>("purged")}");
             await WaitFor(async () => (await Stats(consumer)).Value<int?>("depth") == 0,
                 TimeSpan.FromSeconds(15), "the queue did not end up empty");
         }
@@ -377,7 +389,8 @@ namespace SW.Serverless.UnitTests
 
         // ------------------------------------------------------------------ helpers
 
-        static Dictionary<string, string> Common(string exchange, string queue = null, int intervalMs = 0)
+        static Dictionary<string, string> Common(string exchange, string queue = null, int intervalMs = 0,
+            bool? autoDelete = null)
         {
             var values = new Dictionary<string, string>
             {
@@ -390,6 +403,7 @@ namespace SW.Serverless.UnitTests
                 ["RoutingKey"] = RoutingKey
             };
             if (queue != null) values["Queue"] = queue;
+            if (autoDelete == false) values["AutoDelete"] = "false";
             if (intervalMs > 0) values["IntervalMs"] = intervalMs.ToString();
             return values;
         }


### PR DESCRIPTION
CodeRabbit's review on #109 posted after the squash-merge, so the findings landed on `main`. This fixes them.

## Real defects

| Where | What was wrong |
|---|---|
| `AdapterDashboard.razor` | The **Drain** button called `SetLogLevelAsync` and then told the operator a drain had been requested. It now calls `StopAsync(drain: true)`. |
| `ConsumerHandler.cs` | `BasicAck`/`BasicNack` were called on a shared `IModel` from concurrent `Task.Run` handlers. `RabbitMQ.Client` does not support concurrent application operations on one model. |
| `LargeFileHandler.cs` | Cancellation mid-stream left `accepted` true, so a half-sent file was archived and never resent. The producer-handoff probe also used `FileShare.Read`, which a writer holding the file passes straight through. |
| `DashboardEventSink.cs` | Check-then-act dedupe — the same defect fixed in `TestEventSink` on #108 but not in its sibling. |
| Both event sinks | Dedupe keys were retained for the process lifetime, and full payloads were decoded just to build a 120-char preview. |
| `CarrierHandler.cs` | Could not return to `Connected` after one failed call; retried the delay without the stop token; retried `CreateShipment` with nothing making it idempotent. |
| `CarrierService.cs` | Tracking-number collisions replaced existing shipments (~59% at 40k), and NaN / infinite / non-positive weights were priced. |
| `Spark.razor` | `y="@(23 - height).ToString("0.##")"` rendered the `.ToString(...)` as literal text, and neither attribute was culture-invariant. |
| `DashboardState.cs` | A stopped feed kept reporting a rate from expired timestamps. |

Retries against the carrier are now safe because the simulator deduplicates on the caller's reference and replays the original shipment — and the adapter skips the retry entirely when there is no reference to deduplicate on.

## Tests

Three tests were asserting on timing rather than on behaviour:

- the carrier test picked a random **unreserved** port — port 0 now reserves one from the OS;
- the pause and heartbeat tests could finish the 8/16 MB transfer before ever observing it;
- the purge test let the queue auto-delete when the first consumer stopped, so it purged a brand-new empty queue and asserted `purged >= 0`. It now keeps the queue, waits for the five messages, and asserts them. This needed a new `Consume=false` manage-only mode on the consumer, since an active consumer drains the queue before the purge can see it — which is a genuinely useful mode anyway.

61/61 passing.

## Deliberately not fixed

- **Buf `PACKAGE_DIRECTORY_MATCH`** — Buf is not configured or run in this repository. Restructuring a .NET project's directories to satisfy an unconfigured linter costs more than it returns.
- **Dashboard authorization (CWE-862)** — a sample should not ship an auth system; it would bury what the sample is there to demonstrate. The page now states plainly that it is an unauthenticated developer tool, what the controls can do, and that a real host needs an operator policy at each one.
- **Cleartext transport (CWE-319)** — the plain-HTTP and plain-AMQP defaults exist so the bundled simulator and the test container work out of the box. Both samples now warn on a non-loopback endpoint without TLS, and the Rabbit adapter gained real TLS support (`Tls=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)