### PR TITLE
Resource limits, live updates, and discoverable adapter commands

### DIFF
--- a/SW.Serverless.Contract/Protos/adapter.proto
+++ b/SW.Serverless.Contract/Protos/adapter.proto
@@ -88,6 +88,34 @@ message Hello {
     int32 protocol_version = 4;
     string sdk_version = 5;
     repeated string capabilities = 6;
+
+    // What this adapter can be asked to do, in enough detail to call it without reading its
+    // source. `capabilities` already carries the names as "command:X" and stays as it is for
+    // adapters and hosts built before this field existed; a host that understands this one gets
+    // the shape as well as the name.
+    repeated CommandInfo commands = 7;
+}
+
+// One callable command on an adapter.
+message CommandInfo {
+    string name = 1;
+
+    // The .NET type name of the single argument, or empty when the command takes none. Present so
+    // a caller knows there IS an argument; `parameter_schema` says what it looks like.
+    string parameter_type = 2;
+
+    // The argument's public properties as a JSON object of name -> type, so a UI can build a form
+    // for a command it has never seen. Empty for a primitive or absent argument, where
+    // `parameter_type` already says everything.
+    string parameter_schema = 3;
+
+    // False for a command that returns Task rather than Task<T> — worth knowing before waiting
+    // for an answer that is never coming.
+    bool returns_value = 4;
+
+    // From [AdapterCommand(Description = "…")] on the method. Optional, and worth setting: the
+    // difference between a list of names and a list an operator can act on.
+    string description = 5;
 }
 
 message InvokeResult {

--- a/SW.Serverless.Samples.Greedy/GreedyHandler.cs
+++ b/SW.Serverless.Samples.Greedy/GreedyHandler.cs
@@ -1,3 +1,4 @@
+using SW.Serverless.Sdk;
 using SW.Serverless.Sdk.Resident;
 
 namespace SW.Serverless.Samples.Greedy;
@@ -72,6 +73,7 @@ public class GreedyHandler : IResidentAdapter
     // ---------------------------------------------------------------- commands
 
     /// <summary>Holds another <paramref name="megabytes"/> so the process's RSS actually grows.</summary>
+    [AdapterCommand("Holds another N megabytes, so the process's resident set actually grows.")]
     public Task<object> Allocate(int megabytes)
     {
         AllocateCore(megabytes);
@@ -99,6 +101,7 @@ public class GreedyHandler : IResidentAdapter
     }
 
     /// <summary>Lets go of everything, so a test can prove a ceiling stops tripping.</summary>
+    [AdapterCommand("Releases everything held and collects, so the ceiling stops tripping.")]
     public Task<object> Release()
     {
         lock (_gate) _held.Clear();
@@ -135,6 +138,25 @@ public class GreedyHandler : IResidentAdapter
         });
     }
 
+    /// <summary>
+    /// Takes a shaped argument rather than a primitive, so command discovery has something whose
+    /// schema is worth reporting — a caller can build a form for this without seeing the source.
+    /// </summary>
+    [AdapterCommand("Allocates and optionally burns CPU in one call.")]
+    public Task<object> Strain(StrainRequest request)
+    {
+        if (request == null) return Task.FromResult<object>(new { ok = false });
+
+        if (request.AllocateMb > 0) AllocateCore(request.AllocateMb);
+        if (request.BurnSeconds > 0) StartBurn(request.BurnSeconds);
+
+        return Task.FromResult<object>(new
+        {
+            allocatedMb = Interlocked.Read(ref _allocatedMb),
+            burning = _burn is { IsCompleted: false },
+        });
+    }
+
     public Task<object> GetStats() => Task.FromResult<object>(new
     {
         allocatedMb = Interlocked.Read(ref _allocatedMb),
@@ -142,4 +164,12 @@ public class GreedyHandler : IResidentAdapter
         burning = _burn is { IsCompleted: false },
         state = _state,
     });
+}
+
+/// <summary>The shaped argument for <see cref="GreedyHandler.Strain"/>.</summary>
+public class StrainRequest
+{
+    public int AllocateMb { get; set; }
+    public double BurnSeconds { get; set; }
+    public string Note { get; set; }
 }

--- a/SW.Serverless.Samples.Greedy/GreedyHandler.cs
+++ b/SW.Serverless.Samples.Greedy/GreedyHandler.cs
@@ -1,0 +1,145 @@
+using SW.Serverless.Sdk.Resident;
+
+namespace SW.Serverless.Samples.Greedy;
+
+/// <summary>
+/// An adapter that misbehaves on request, so the host's resource ceilings have something real to
+/// act on.
+///
+/// The limits are enforced against a live operating-system process — resident set size and
+/// processor time — so a fake cannot exercise them. This allocates for real and burns a core for
+/// real, which is the only way to find out whether the watchdog samples, decides and acts the way
+/// it claims to.
+///
+/// It also reports honestly while doing it, because half of what the ceilings are for is being
+/// visible before they fire.
+/// </summary>
+public class GreedyHandler : IResidentAdapter
+{
+    private IAdapterContext _context;
+    private CancellationTokenSource _stopping;
+
+    // Held in a field, not a local: the whole point is that the GC cannot reclaim it, or RSS never
+    // moves and the soft ceiling never trips.
+    private readonly List<byte[]> _held = new();
+    private readonly object _gate = new();
+
+    private volatile string _state = "Idle";
+    private long _allocatedMb;
+    private Task _burn;
+
+    public Task StartAsync(IAdapterContext context, CancellationToken cancellationToken)
+    {
+        _context = context;
+        _stopping = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _state = "Ready";
+
+        // Allocate at startup when asked, so a test can watch a ceiling fire without a round trip
+        // — the adapter is over the line before the first heartbeat samples it.
+        if (int.TryParse(context.StartupValueOf("AllocateMbOnStart"), out var mb) && mb > 0)
+            AllocateCore(mb);
+
+        if (double.TryParse(context.StartupValueOf("BurnCpuOnStart"), out var seconds) && seconds > 0)
+            StartBurn(seconds);
+
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _state = "Stopped";
+        _stopping?.Cancel();
+        lock (_gate) _held.Clear();
+        return Task.CompletedTask;
+    }
+
+    public Task<AdapterStatus> GetStatusAsync()
+    {
+        var status = new AdapterStatus
+        {
+            Connected = true,
+            State = _state,
+        };
+
+        status.Details["allocatedMb"] = Interlocked.Read(ref _allocatedMb).ToString();
+        status.Details["workingSetMb"] =
+            (Environment.WorkingSet / 1024 / 1024).ToString();
+        status.Details["burning"] = (_burn is { IsCompleted: false }).ToString();
+
+        return Task.FromResult(status);
+    }
+
+    // ---------------------------------------------------------------- commands
+
+    /// <summary>Holds another <paramref name="megabytes"/> so the process's RSS actually grows.</summary>
+    public Task<object> Allocate(int megabytes)
+    {
+        AllocateCore(megabytes);
+        return Task.FromResult<object>(new { allocatedMb = Interlocked.Read(ref _allocatedMb) });
+    }
+
+    private void AllocateCore(int megabytes)
+    {
+        _state = "Allocating";
+
+        for (var i = 0; i < megabytes; i++)
+        {
+            var block = new byte[1024 * 1024];
+
+            // Touch every page. A .NET array is committed lazily enough that an untouched
+            // allocation may never appear in the resident set — and RSS is what the host samples.
+            for (var b = 0; b < block.Length; b += 4096) block[b] = 1;
+
+            lock (_gate) _held.Add(block);
+            Interlocked.Increment(ref _allocatedMb);
+        }
+
+        _state = "Allocated";
+        _context?.LogInformation($"Holding {Interlocked.Read(ref _allocatedMb)} MB.");
+    }
+
+    /// <summary>Lets go of everything, so a test can prove a ceiling stops tripping.</summary>
+    public Task<object> Release()
+    {
+        lock (_gate) _held.Clear();
+        Interlocked.Exchange(ref _allocatedMb, 0);
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+        _state = "Ready";
+        return Task.FromResult<object>(new { allocatedMb = 0 });
+    }
+
+    /// <summary>Pegs a core for a while, so the sustained CPU ceiling has something to sample.</summary>
+    public Task<object> BurnCpu(double seconds)
+    {
+        StartBurn(seconds);
+        return Task.FromResult<object>(new { burningFor = seconds });
+    }
+
+    private void StartBurn(double seconds)
+    {
+        var until = DateTime.UtcNow.AddSeconds(seconds);
+        _state = "Burning";
+
+        _burn = Task.Run(() =>
+        {
+            // A tight loop on purpose: the ceiling is about sustained processor time, and anything
+            // that yields would not produce it.
+            var spin = 0UL;
+            while (DateTime.UtcNow < until && !(_stopping?.IsCancellationRequested ?? false))
+                for (var i = 0; i < 5_000_000; i++) spin += (ulong)i;
+
+            _state = "Ready";
+            _context?.LogInformation($"Burn finished ({spin & 1}).");
+        });
+    }
+
+    public Task<object> GetStats() => Task.FromResult<object>(new
+    {
+        allocatedMb = Interlocked.Read(ref _allocatedMb),
+        workingSetMb = Environment.WorkingSet / 1024 / 1024,
+        burning = _burn is { IsCompleted: false },
+        state = _state,
+    });
+}

--- a/SW.Serverless.Samples.Greedy/Program.cs
+++ b/SW.Serverless.Samples.Greedy/Program.cs
@@ -1,0 +1,10 @@
+using SW.Serverless.Sdk;
+using System.Threading.Tasks;
+
+namespace SW.Serverless.Samples.Greedy
+{
+    static class Program
+    {
+        static Task Main() => Runner.RunResident(new GreedyHandler());
+    }
+}

--- a/SW.Serverless.Samples.Greedy/SW.Serverless.Samples.Greedy.csproj
+++ b/SW.Serverless.Samples.Greedy/SW.Serverless.Samples.Greedy.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AssemblyName>SW.Serverless.Samples.Greedy</AssemblyName>
+    <RootNamespace>SW.Serverless.Samples.Greedy</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../SW.Serverless.Sdk/SW.Serverless.Sdk.csproj" />
+  </ItemGroup>
+</Project>

--- a/SW.Serverless.Sdk/AdapterCommandAttribute.cs
+++ b/SW.Serverless.Sdk/AdapterCommandAttribute.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace SW.Serverless.Sdk
+{
+    /// <summary>
+    /// Describes a command in words, so what an adapter exposes can be read without its source.
+    ///
+    /// Entirely optional — every public Task-returning method is discovered and callable without
+    /// it. What this adds is the difference between a list of names and a list an operator can act
+    /// on: "GetStats" tells you nothing about whether it is safe to click during an incident.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class AdapterCommandAttribute : Attribute
+    {
+        public AdapterCommandAttribute(string description = null) => Description = description;
+
+        /// <summary>What the command does, in one line, for whoever is deciding whether to run it.</summary>
+        public string Description { get; set; }
+    }
+}

--- a/SW.Serverless.Sdk/Resident/ResidentRunner.cs
+++ b/SW.Serverless.Sdk/Resident/ResidentRunner.cs
@@ -132,7 +132,8 @@ namespace SW.Serverless.Sdk.Resident
                     InstanceKey = handshake.InstanceKey ?? "",
                     ProtocolVersion = ProtocolVersion,
                     SdkVersion = typeof(ResidentRunner).Assembly.GetName().Version?.ToString() ?? "0.0.0",
-                    Capabilities = { Capabilities() }
+                    Capabilities = { Capabilities() },
+                    Commands = { CommandInfos() }
                 }
             });
 
@@ -144,6 +145,73 @@ namespace SW.Serverless.Sdk.Resident
             await Task.WhenAny(writer, Task.Delay(2000));
             try { await call.RequestStream.CompleteAsync(); } catch { /* already torn down */ }
             _ = stdinWatch;
+        }
+
+        /// <summary>
+        /// The same commands `capabilities` names, with the shape a caller needs to actually
+        /// invoke one: whether it takes an argument, what that argument looks like, and whether
+        /// anything comes back.
+        /// </summary>
+        IEnumerable<CommandInfo> CommandInfos()
+        {
+            foreach (var pair in commands)
+            {
+                var method = pair.Value.MethodInfo;
+                var parameterType = pair.Value.ParameterType;
+
+                var info = new CommandInfo
+                {
+                    Name = pair.Key,
+                    ParameterType = parameterType?.Name ?? "",
+                    ParameterSchema = DescribeParameter(parameterType),
+                    ReturnsValue = !pair.Value.Void,
+                    Description = method.GetCustomAttribute<AdapterCommandAttribute>()?.Description ?? ""
+                };
+
+                yield return info;
+            }
+        }
+
+        /// <summary>
+        /// A complex argument's public properties as name -> type, so a UI can build a form for a
+        /// command it has never seen. Primitives and strings describe themselves through
+        /// ParameterType, so they get nothing here rather than a pointless one-entry object.
+        /// </summary>
+        static string DescribeParameter(Type parameterType)
+        {
+            if (parameterType == null) return "";
+            if (parameterType.IsPrimitive || parameterType == typeof(string) ||
+                parameterType == typeof(decimal) || parameterType == typeof(DateTime) ||
+                parameterType == typeof(Guid))
+                return "";
+
+            try
+            {
+                var properties = parameterType
+                    .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                    .Where(p => p.CanRead)
+                    .ToDictionary(p => p.Name, p => FriendlyName(p.PropertyType));
+
+                return properties.Count == 0
+                    ? ""
+                    : System.Text.Json.JsonSerializer.Serialize(properties);
+            }
+            catch
+            {
+                // Describing an argument must never stop an adapter attaching.
+                return "";
+            }
+        }
+
+        static string FriendlyName(Type type)
+        {
+            var underlying = Nullable.GetUnderlyingType(type);
+            if (underlying != null) return FriendlyName(underlying) + "?";
+            if (type.IsArray) return FriendlyName(type.GetElementType()) + "[]";
+            if (type.IsGenericType)
+                return type.Name.Split('`')[0] + "<" +
+                       string.Join(", ", type.GetGenericArguments().Select(FriendlyName)) + ">";
+            return type.Name;
         }
 
         IEnumerable<string> Capabilities()

--- a/SW.Serverless.UnitTests/CommandDiscoveryTests.cs
+++ b/SW.Serverless.UnitTests/CommandDiscoveryTests.cs
@@ -1,0 +1,204 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using SW.CloudFiles.Extensions;
+using SW.PrimitiveTypes;
+using SW.Serverless.Resident;
+using SW.Serverless.UnitTests.Fixtures;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SW.Serverless.UnitTests
+{
+    /// <summary>
+    /// What an adapter can be asked to do, discovered rather than documented.
+    ///
+    /// An adapter is a zip in cloud storage written by somebody else, possibly a long time ago. The
+    /// host has always known the NAMES of its commands; what it could not answer is whether a
+    /// command takes an argument, what that argument looks like, or whether anything comes back —
+    /// so anything wanting to offer those commands had to hard-code them, which is the same as not
+    /// discovering them at all.
+    /// </summary>
+    [TestClass]
+    public class CommandDiscoveryTests
+    {
+        const string GreedyId = "test.discovery";
+
+        static IHost host;
+        static IResidentAdapterHost adapters;
+
+        [ClassInitialize]
+        public static async Task ClassInitialize(TestContext context)
+        {
+            host = Host.CreateDefaultBuilder()
+                .ConfigureLogging(l => l.ClearProviders())
+                .ConfigureServices(s =>
+                {
+                    s.AddLocalTestsCloudFiles(o => o.BucketName = TestStore.BucketName + "-discovery");
+                    s.AddServerless(o =>
+                    {
+                        o.AdapterRemotePath = "adapters";
+                        o.AdapterLocalPath = Path.Combine(Path.GetTempPath(), "swsl-disctests", "installed");
+                        o.AdapterMetadataCacheDuration = 1;
+                    });
+                    s.AddSingleton<TestEventSink>();
+                    s.AddSingleton<IAdapterEventSink>(sp => sp.GetRequiredService<TestEventSink>());
+                    s.AddResidentAdapters<TestEventSink>(o =>
+                    {
+                        o.SocketPath = $"/tmp/swsl-d{Environment.ProcessId}.sock";
+                        o.PipeName = $"swsl-d{Environment.ProcessId}";
+                        o.HeartbeatInterval = TimeSpan.FromSeconds(2);
+                        o.HandshakeTimeout = TimeSpan.FromSeconds(30);
+                    });
+                })
+                .Build();
+
+            await host.StartAsync();
+            adapters = host.Services.GetRequiredService<IResidentAdapterHost>();
+
+            await TestStore.PublishAsync(host.Services.GetRequiredService<ICloudFilesService>(),
+                GreedyId, "SW.Serverless.Samples.Greedy",
+                new Dictionary<string, string> { ["Protocol"] = "2", ["Lifecycle"] = "resident" });
+
+            await adapters.StartExclusiveAsync(new AdapterSpec
+            {
+                AdapterId = GreedyId,
+                InstanceKey = "discovery",
+            });
+        }
+
+        [ClassCleanup]
+        public static async Task ClassCleanup()
+        {
+            if (host != null) await host.StopAsync();
+            host?.Dispose();
+            try { Directory.Delete(Path.Combine(Path.GetTempPath(), "swsl-disctests"), true); } catch { }
+        }
+
+        static IReadOnlyCollection<AdapterCommand> Commands() =>
+            adapters.Describe().Single(h => h.InstanceKey == "discovery").CommandDetails;
+
+        [TestMethod]
+        public void Every_public_command_is_discovered_without_being_declared_anywhere()
+        {
+            var names = Commands().Select(c => c.Name).ToList();
+
+            CollectionAssert.IsSubsetOf(
+                new[] { "Allocate", "Release", "BurnCpu", "GetStats", "Strain" },
+                names.ToList());
+
+            // The lifecycle methods are not commands. Offering StopAsync as something to click
+            // would hand an operator a way to stop an adapter that looks like any other action.
+            CollectionAssert.DoesNotContain(names, "StartAsync");
+            CollectionAssert.DoesNotContain(names, "StopAsync");
+            CollectionAssert.DoesNotContain(names, "GetStatusAsync");
+        }
+
+        /// <summary>
+        /// Whether a command takes an argument, and of what type. Without this a caller can only
+        /// guess, and guessing wrong on a command that writes to a customer's system is not a
+        /// mistake anyone wants to make twice.
+        /// </summary>
+        [TestMethod]
+        public void A_commands_argument_is_described()
+        {
+            var allocate = Commands().Single(c => c.Name == "Allocate");
+            Assert.IsTrue(allocate.TakesArgument);
+            Assert.AreEqual("Int32", allocate.ParameterType);
+            Assert.IsTrue(allocate.ReturnsValue);
+
+            var release = Commands().Single(c => c.Name == "Release");
+            Assert.IsFalse(release.TakesArgument, "Release takes nothing and should say so");
+            Assert.AreEqual("", release.ParameterType);
+        }
+
+        /// <summary>
+        /// A shaped argument comes with its properties, which is what lets a UI build a form for a
+        /// command it has never seen — the difference between discovery and a list of names.
+        /// </summary>
+        [TestMethod]
+        public void A_shaped_argument_carries_its_properties()
+        {
+            var strain = Commands().Single(c => c.Name == "Strain");
+
+            Assert.AreEqual("StrainRequest", strain.ParameterType);
+            Assert.IsFalse(string.IsNullOrEmpty(strain.ParameterSchema),
+                "a complex argument should describe its shape");
+
+            var schema = JObject.Parse(strain.ParameterSchema);
+            Assert.AreEqual("Int32", schema.Value<string>("AllocateMb"));
+            Assert.AreEqual("Double", schema.Value<string>("BurnSeconds"));
+            Assert.AreEqual("String", schema.Value<string>("Note"));
+        }
+
+        /// <summary>
+        /// A primitive argument gets no schema. An object with one entry called "value" would be
+        /// noise pretending to be information — ParameterType already said everything.
+        /// </summary>
+        [TestMethod]
+        public void A_primitive_argument_gets_no_schema()
+        {
+            var allocate = Commands().Single(c => c.Name == "Allocate");
+            Assert.AreEqual("", allocate.ParameterSchema);
+        }
+
+        [TestMethod]
+        public void A_description_reaches_the_host_when_the_author_wrote_one()
+        {
+            var allocate = Commands().Single(c => c.Name == "Allocate");
+            StringAssert.Contains(allocate.Description, "megabytes");
+
+            // And an undescribed command is still discovered — the attribute is optional.
+            var stats = Commands().Single(c => c.Name == "GetStats");
+            Assert.IsNotNull(stats);
+            Assert.AreEqual("", stats.Description);
+        }
+
+        /// <summary>
+        /// The names list stays exactly as it was. An adapter built against an older SDK sends no
+        /// descriptors at all, and everything reading the old field has to keep working — so the
+        /// two are kept in step rather than one replacing the other.
+        /// </summary>
+        [TestMethod]
+        public void The_names_and_the_descriptors_agree()
+        {
+            var health = adapters.Describe().Single(h => h.InstanceKey == "discovery");
+
+            CollectionAssert.AreEquivalent(
+                health.Commands.OrderBy(c => c).ToList(),
+                health.CommandDetails.Select(c => c.Name).OrderBy(c => c).ToList());
+        }
+
+        /// <summary>
+        /// Discovery is only worth anything if what it describes can then be called. This takes a
+        /// command's declared shape and invokes it from that alone.
+        /// </summary>
+        [TestMethod]
+        public async Task A_discovered_command_can_be_called_from_its_description_alone()
+        {
+            var strain = Commands().Single(c => c.Name == "Strain");
+            var schema = JObject.Parse(strain.ParameterSchema);
+
+            // Built from the schema, not from knowledge of StrainRequest.
+            var argument = new JObject();
+            foreach (var property in schema.Properties())
+                argument[property.Name] = property.Value.ToString() switch
+                {
+                    "Int32" => 7,
+                    "Double" => 0d,
+                    _ => (JToken)"from discovery",
+                };
+
+            var result = await adapters.Get(GreedyId, "discovery")
+                .InvokeAsync<JObject>(strain.Name, argument, timeoutSeconds: 30);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(7, result.Value<int>("allocatedMb"));
+        }
+    }
+}

--- a/SW.Serverless.UnitTests/ResourceLimitTests.cs
+++ b/SW.Serverless.UnitTests/ResourceLimitTests.cs
@@ -1,0 +1,465 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using SW.CloudFiles.Extensions;
+using SW.PrimitiveTypes;
+using SW.Serverless.Resident;
+using SW.Serverless.UnitTests.Fixtures;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SW.Serverless.UnitTests
+{
+    /// <summary>
+    /// The ceilings an adapter process runs under, and how they are changed while it runs.
+    ///
+    /// An adapter is a separate process the host does not otherwise constrain. Without a ceiling,
+    /// one runaway payload is bounded by nothing but the machine, and every other adapter on the
+    /// node goes down with it — so these limits are the difference between one integration failing
+    /// and the node failing. They were enforced against real process metrics and covered by nothing.
+    ///
+    /// Everything here runs a REAL adapter that allocates real memory and burns a real core,
+    /// because the watchdog samples the operating system: resident set size and processor time. A
+    /// fake would prove only that the test agrees with itself.
+    /// </summary>
+    [TestClass]
+    public class ResourceLimitTests
+    {
+        const string GreedyId = "test.greedy";
+
+        // Short enough that a test does not wait a minute for the watchdog, long enough that the
+        // CPU average has real wall time behind it.
+        static readonly TimeSpan Heartbeat = TimeSpan.FromMilliseconds(700);
+
+        static IHost host;
+        static IResidentAdapterHost adapters;
+
+        [ClassInitialize]
+        public static async Task ClassInitialize(TestContext context)
+        {
+            host = Host.CreateDefaultBuilder()
+                .ConfigureLogging(l => l.ClearProviders())
+                .ConfigureServices(s =>
+                {
+                    s.AddLocalTestsCloudFiles(o => o.BucketName = TestStore.BucketName + "-limits");
+                    s.AddServerless(o =>
+                    {
+                        o.AdapterRemotePath = "adapters";
+                        o.AdapterLocalPath = Path.Combine(Path.GetTempPath(), "swsl-limittests", "installed");
+                        o.AdapterMetadataCacheDuration = 1;
+                    });
+                    s.AddSingleton<TestEventSink>();
+                    s.AddSingleton<IAdapterEventSink>(sp => sp.GetRequiredService<TestEventSink>());
+                    s.AddResidentAdapters<TestEventSink>(o =>
+                    {
+                        o.SocketPath = $"/tmp/swsl-l{Environment.ProcessId}.sock";
+                        o.PipeName = $"swsl-l{Environment.ProcessId}";
+                        o.HeartbeatInterval = Heartbeat;
+                        o.HandshakeTimeout = TimeSpan.FromSeconds(30);
+
+                        // Crash-loop quarantine would otherwise stop the restarts these tests are
+                        // about: a ceiling firing repeatedly looks exactly like a crash loop.
+                        o.CrashLoopThreshold = 50;
+                    });
+                })
+                .Build();
+
+            await host.StartAsync();
+            adapters = host.Services.GetRequiredService<IResidentAdapterHost>();
+
+            await TestStore.PublishAsync(host.Services.GetRequiredService<ICloudFilesService>(),
+                GreedyId, "SW.Serverless.Samples.Greedy",
+                new Dictionary<string, string> { ["Protocol"] = "2", ["Lifecycle"] = "resident" });
+        }
+
+        [ClassCleanup]
+        public static async Task ClassCleanup()
+        {
+            if (host != null) await host.StopAsync();
+            host?.Dispose();
+            try { Directory.Delete(Path.Combine(Path.GetTempPath(), "swsl-limittests"), true); } catch { }
+        }
+
+        // ---------------------------------------------------------------- memory
+
+        /// <summary>
+        /// The soft ceiling is the one that should normally fire, and it must fire GENTLY: the
+        /// adapter is asked to drain, so whatever is in flight is finished or handed back rather
+        /// than lost. A restart proves the watchdog acted; the drain request proves it chose the
+        /// graceful path rather than a kill.
+        /// </summary>
+        [TestMethod]
+        public async Task A_soft_memory_ceiling_asks_the_adapter_to_drain_and_it_comes_back()
+        {
+            var instance = await StartAsync("soft", allocateOnStartMb: 220, spec => spec
+                .WithSoftMemory(120));
+
+            var first = instance.Process?.Id;
+            Assert.IsNotNull(first);
+
+            // A new process under the same key: the watchdog sampled, decided, and the supervisor
+            // relaunched it.
+            var replacement = await WaitForNewProcessAsync("soft", first.Value, TimeSpan.FromSeconds(45));
+
+            Assert.AreNotEqual(first.Value, replacement,
+                "the soft memory ceiling never fired");
+
+            // And it is serviceable afterwards, rather than merely restarted. The replacement is
+            // still spawning the instant its pid appears, so this waits for the handshake.
+            await WaitForReadyAsync("soft", TimeSpan.FromSeconds(30));
+            var stats = await adapters.Get(GreedyId, "soft")
+                .InvokeAsync<JObject>("GetStats", timeoutSeconds: 15);
+            Assert.IsNotNull(stats);
+        }
+
+        /// <summary>
+        /// The hard ceiling is the backstop, and it does not negotiate. An adapter that ignores a
+        /// drain — or grows faster than it can drain — is killed, because at that point the choice
+        /// is between one adapter's in-flight work and the whole node.
+        /// </summary>
+        [TestMethod]
+        public async Task A_hard_memory_ceiling_kills_an_adapter_that_will_not_stop_growing()
+        {
+            var instance = await StartAsync("hard", allocateOnStartMb: 260, spec => spec
+                .WithHardMemory(140));
+
+            var first = instance.Process?.Id;
+            Assert.IsNotNull(first);
+
+            var replacement = await WaitForNewProcessAsync("hard", first.Value, TimeSpan.FromSeconds(45));
+            Assert.AreNotEqual(first.Value, replacement, "the hard memory ceiling never fired");
+        }
+
+        /// <summary>
+        /// A ceiling set on the spec beats the host default, or a per-adapter limit would be
+        /// decoration: every adapter on a node would run under whichever number the host happened
+        /// to be configured with.
+        /// </summary>
+        [TestMethod]
+        public async Task A_ceiling_on_the_spec_overrides_the_host_default()
+        {
+            // The host default here is 0 — off — so a spec-level ceiling firing at all is the
+            // proof that the spec is consulted first.
+            var options = host.Services.GetRequiredService<Microsoft.Extensions.Options.IOptions<ResidentOptions>>();
+            Assert.AreEqual(0, options.Value.SoftMemoryLimitBytes,
+                "this test's premise is that the host default is off");
+
+            var instance = await StartAsync("override", allocateOnStartMb: 200, spec => spec
+                .WithSoftMemory(110));
+
+            var first = instance.Process?.Id;
+            var replacement = await WaitForNewProcessAsync("override", first!.Value, TimeSpan.FromSeconds(45));
+
+            Assert.AreNotEqual(first.Value, replacement);
+        }
+
+        /// <summary>
+        /// An adapter comfortably inside its ceiling is left alone. Without this the others prove
+        /// only that something restarts adapters — not that the limit is what decided it.
+        /// </summary>
+        [TestMethod]
+        public async Task An_adapter_within_its_ceiling_is_never_touched()
+        {
+            var instance = await StartAsync("quiet", allocateOnStartMb: 20, spec => spec
+                .WithSoftMemory(400).WithHardMemory(600));
+
+            var first = instance.Process?.Id;
+            Assert.IsNotNull(first);
+
+            // Several watchdog passes, so "not yet" cannot pass for "never".
+            await Task.Delay(Heartbeat * 8);
+
+            Assert.AreEqual(first.Value, adapters.Get(GreedyId, "quiet")?.Process?.Id,
+                "an adapter inside its ceiling was recycled anyway");
+        }
+
+        // ---------------------------------------------------------------- cpu
+
+        /// <summary>
+        /// Sustained CPU trips the ceiling and asks for a drain.
+        ///
+        /// The burn outlasts the sample window on purpose: the point of the rule is that it fires
+        /// on a run of samples, so the adapter has to still be pegged when the streak completes.
+        /// </summary>
+        [TestMethod]
+        public async Task Sustained_cpu_trips_the_ceiling_and_recycles_the_adapter()
+        {
+            // CpuPercent is a share of the WHOLE machine, so a single pegged core reads
+            // 100/ProcessorCount — about 10% here. A ceiling above that could never be reached by
+            // one busy thread, which is exactly the trap the metric's documentation now warns about.
+            var onePeggedCore = 100.0 / Environment.ProcessorCount;
+            var instance = await StartAsync("cpu", burnCpuOnStartSeconds: 30, configure: spec => spec
+                .WithCpu(percent: onePeggedCore / 3, samples: 2));
+
+            var first = instance.Process?.Id;
+            Assert.IsNotNull(first);
+
+            var replacement = await WaitForNewProcessAsync("cpu", first.Value, TimeSpan.FromSeconds(45));
+            Assert.AreNotEqual(first.Value, replacement, "the sustained CPU ceiling never fired");
+        }
+
+        /// <summary>
+        /// A burst does NOT trip it — and this is the test that gives the rule its meaning.
+        ///
+        /// An adapter draining a backlog is supposed to peg a core. A ceiling that recycled it for
+        /// working hard would be a bug wearing a limit's clothes, so the streak has to be long
+        /// enough that a short burst passes underneath it.
+        /// </summary>
+        [TestMethod]
+        public async Task A_short_burst_of_work_does_not_trip_the_cpu_ceiling()
+        {
+            var instance = await StartAsync("burst", configure: spec => spec
+                // A reachable ceiling — the burst really does exceed it — but ten consecutive
+                // samples is about seven seconds of solid CPU at this heartbeat, and the burst is
+                // a fraction of that. So the streak, not the threshold, is what saves it.
+                .WithCpu(percent: 100.0 / Environment.ProcessorCount / 3, samples: 10));
+
+            var first = instance.Process?.Id;
+            Assert.IsNotNull(first);
+
+            await instance.InvokeAsync<JObject>("BurnCpu", 1.5, timeoutSeconds: 15);
+            await Task.Delay(Heartbeat * 8);
+
+            Assert.AreEqual(first.Value, adapters.Get(GreedyId, "burst")?.Process?.Id,
+                "a short burst of legitimate work recycled the adapter");
+        }
+
+        // ---------------------------------------------------------------- update / restart
+
+        /// <summary>
+        /// The soft ceiling can be changed on a running adapter and takes effect without a
+        /// restart: it is read from the spec on every sample. An operator tightening a limit
+        /// during an incident should not have to bounce the connection to do it.
+        ///
+        /// The adapter grows AFTER the ceiling is lowered rather than merely sitting above it,
+        /// because resident set size is not a number the process fully controls — the operating
+        /// system reclaims pages under pressure, so a heap that was over the line a moment ago can
+        /// drift back under it while nothing at all has changed. Growing into the new ceiling is
+        /// the same behaviour under test and does not depend on the OS holding still.
+        /// </summary>
+        [TestMethod]
+        public async Task Lowering_the_soft_ceiling_takes_effect_without_a_restart()
+        {
+            var instance = await StartAsync("update-soft", allocateOnStartMb: 60, spec => spec
+                .WithSoftMemory(800));   // far above anything this test allocates
+
+            var first = instance.Process?.Id;
+            Assert.IsNotNull(first);
+
+            await Task.Delay(Heartbeat * 3);
+            Assert.AreEqual(first, adapters.Get(GreedyId, "update-soft")?.Process?.Id,
+                "nothing should have fired while the ceiling was 800 MB");
+
+            var update = await adapters.UpdateLimitsAsync(GreedyId, "update-soft",
+                new ResourceLimits { SoftMemoryLimitBytes = Mb(200) });
+
+            Assert.IsTrue(update.Applied);
+            Assert.IsFalse(update.RestartRequired,
+                "the soft ceiling is read every sample, so it needs no restart");
+
+            // Over the NEW ceiling and nowhere near the old one, so what happens next can only be
+            // the lowered limit.
+            try
+            {
+                await adapters.Get(GreedyId, "update-soft")
+                    .InvokeAsync<JObject>("Allocate", 260, timeoutSeconds: 60);
+            }
+            catch (AdapterInvocationException)
+            {
+                // The drain can land mid-allocation and take the command with it. That is the
+                // ceiling firing, which is what the test is here to observe.
+            }
+
+            var replacement = await WaitForNewProcessAsync("update-soft", first.Value, TimeSpan.FromSeconds(45));
+            Assert.AreNotEqual(first.Value, replacement, "the lowered ceiling never took effect");
+        }
+
+        /// <summary>
+        /// The hard ceiling is the runtime's own GC heap limit, handed over when the process
+        /// launched. It cannot change in place, and the host says so rather than accepting the
+        /// change and quietly running under the old number — which is the failure an operator
+        /// could not possibly detect.
+        /// </summary>
+        [TestMethod]
+        public async Task Changing_the_hard_ceiling_reports_that_a_restart_is_required()
+        {
+            await StartAsync("update-hard", allocateOnStartMb: 10, spec => spec.WithHardMemory(500));
+
+            var update = await adapters.UpdateLimitsAsync(GreedyId, "update-hard",
+                new ResourceLimits { HardMemoryLimitBytes = Mb(250) });
+
+            Assert.IsTrue(update.Applied);
+            Assert.IsTrue(update.RestartRequired);
+            StringAssert.Contains(update.Reason, "restart", StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Restarting keeps the instance in place under the same key. That matters beyond
+        /// tidiness: in Bitween the key is the data source, and dropping the registry entry would
+        /// release the lease that makes the broker connection exclusive — so a restart would
+        /// briefly become a handover.
+        /// </summary>
+        [TestMethod]
+        public async Task Restarting_relaunches_in_place_under_the_same_key()
+        {
+            // No allocate-on-start: a relaunched process re-applies its startup values, so
+            // "allocated 0" only means "fresh" when nothing told it to allocate.
+            var instance = await StartAsync("restart");
+            var first = instance.Process?.Id;
+            Assert.IsNotNull(first);
+
+            var restarted = await adapters.RestartAsync(GreedyId, "restart", drain: false);
+
+            Assert.IsNotNull(restarted);
+            Assert.AreNotEqual(first.Value, restarted.Process?.Id, "nothing was relaunched");
+            Assert.AreEqual(InstanceState.Ready, restarted.State);
+
+            // Same key, still exactly one instance — not a second one beside the first.
+            var here = adapters.Describe().Where(h => h.InstanceKey == "restart").ToList();
+            Assert.AreEqual(1, here.Count);
+            Assert.AreEqual(GreedyId, here[0].AdapterId);
+
+            // And it works, rather than merely existing.
+            await adapters.Get(GreedyId, "restart").InvokeAsync<JObject>("Allocate", 5, timeoutSeconds: 30);
+            var stats = await adapters.Get(GreedyId, "restart")
+                .InvokeAsync<JObject>("GetStats", timeoutSeconds: 15);
+
+            Assert.IsNotNull(stats);
+            Assert.AreEqual(5, stats.Value<int>("allocatedMb"),
+                "the relaunched process should be serving commands with a heap of its own");
+        }
+
+        /// <summary>
+        /// A restart is what actually applies a hard ceiling — and the proof is that the runtime
+        /// then refuses the allocation itself.
+        ///
+        /// This is the containment working at its best. The hard ceiling is handed to the child as
+        /// DOTNET_GCHeapHardLimit, so an allocation past it throws OutOfMemoryException INSIDE the
+        /// adapter and comes back to the caller as a failed command. The watchdog's kill is the
+        /// backstop behind that, not the first line: the node never sees the memory at all.
+        /// </summary>
+        [TestMethod]
+        public async Task A_restart_applies_a_hard_ceiling_and_the_runtime_then_refuses_the_allocation()
+        {
+            var instance = await StartAsync("update-then-restart", allocateOnStartMb: 10,
+                spec => spec.WithHardMemory(600));
+            var first = instance.Process?.Id;
+
+            // Comfortably allowed under the ceiling it started with.
+            await adapters.Get(GreedyId, "update-then-restart")
+                .InvokeAsync<JObject>("Allocate", 120, timeoutSeconds: 60);
+
+            var update = await adapters.UpdateLimitsAsync(GreedyId, "update-then-restart",
+                new ResourceLimits { HardMemoryLimitBytes = Mb(150) });
+            Assert.IsTrue(update.RestartRequired);
+
+            await adapters.RestartAsync(GreedyId, "update-then-restart", drain: false);
+            await WaitForReadyAsync("update-then-restart", TimeSpan.FromSeconds(30));
+
+            var afterRestart = adapters.Get(GreedyId, "update-then-restart")?.Process?.Id;
+            Assert.AreNotEqual(first, afterRestart);
+
+            // The same allocation that was fine a moment ago is now refused by the runtime, which
+            // is the new ceiling being genuinely in force rather than merely recorded.
+            var refused = await Assert.ThrowsExceptionAsync<AdapterInvocationException>(
+                () => adapters.Get(GreedyId, "update-then-restart")
+                    .InvokeAsync<JObject>("Allocate", 400, timeoutSeconds: 60));
+
+            StringAssert.Contains(refused.Message, "OutOfMemory",
+                "the allocation failed for some reason other than the heap ceiling");
+        }
+
+        [TestMethod]
+        public async Task Updating_limits_on_an_instance_that_is_not_running_says_so()
+        {
+            var update = await adapters.UpdateLimitsAsync(GreedyId, "never-started",
+                new ResourceLimits { SoftMemoryLimitBytes = Mb(100) });
+
+            Assert.IsFalse(update.Applied);
+            Assert.IsNotNull(update.Reason);
+        }
+
+        [TestMethod]
+        public async Task Restarting_an_instance_that_is_not_running_throws_rather_than_starting_one()
+        {
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => adapters.RestartAsync(GreedyId, "also-never-started"));
+        }
+
+        // ---------------------------------------------------------------- helpers
+
+        static long Mb(int megabytes) => (long)megabytes * 1024 * 1024;
+
+        static async Task<ResidentAdapterInstance> StartAsync(string key,
+            int allocateOnStartMb = 0, Action<AdapterSpec> configure = null,
+            double burnCpuOnStartSeconds = 0)
+        {
+            var spec = new AdapterSpec { AdapterId = GreedyId, InstanceKey = key };
+
+            // Over the line before the first sample, so the watchdog's decision is the only thing
+            // the test is waiting on.
+            if (allocateOnStartMb > 0)
+                spec.StartupValues["AllocateMbOnStart"] = allocateOnStartMb.ToString();
+            if (burnCpuOnStartSeconds > 0)
+                spec.StartupValues["BurnCpuOnStart"] = burnCpuOnStartSeconds.ToString();
+
+            configure?.Invoke(spec);
+            return await adapters.StartExclusiveAsync(spec);
+        }
+
+        /// <summary>A relaunched instance is Spawning before it is Ready; commands need Ready.</summary>
+        static async Task WaitForReadyAsync(string key, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (adapters.Get(GreedyId, key)?.State == InstanceState.Ready) return;
+                await Task.Delay(200);
+            }
+            Assert.Fail($"'{key}' never became Ready within {timeout}.");
+        }
+
+        /// <summary>
+        /// Waits for a DIFFERENT process under the same key — which is what "the watchdog acted"
+        /// looks like from outside, whether it drained or killed.
+        /// </summary>
+        static async Task<int> WaitForNewProcessAsync(string key, int original, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                var current = adapters.Get(GreedyId, key)?.Process?.Id;
+                if (current.HasValue && current.Value != original) return current.Value;
+                await Task.Delay(200);
+            }
+            return original;
+        }
+    }
+
+    static class SpecLimitExtensions
+    {
+        public static AdapterSpec WithSoftMemory(this AdapterSpec spec, int megabytes)
+        {
+            spec.SoftMemoryLimitBytes = (long)megabytes * 1024 * 1024;
+            return spec;
+        }
+
+        public static AdapterSpec WithHardMemory(this AdapterSpec spec, int megabytes)
+        {
+            spec.HardMemoryLimitBytes = (long)megabytes * 1024 * 1024;
+            return spec;
+        }
+
+        public static AdapterSpec WithCpu(this AdapterSpec spec, double percent, int samples)
+        {
+            spec.CpuPercentLimit = percent;
+            spec.CpuLimitSamples = samples;
+            return spec;
+        }
+    }
+}

--- a/SW.Serverless.UnitTests/SW.Serverless.UnitTests.csproj
+++ b/SW.Serverless.UnitTests/SW.Serverless.UnitTests.csproj
@@ -41,6 +41,8 @@
                           ReferenceOutputAssembly="false" />
         <ProjectReference Include="..\SW.Serverless.Samples.Carrier\SW.Serverless.Samples.Carrier.csproj"
                           ReferenceOutputAssembly="false" />
+        <ProjectReference Include="..\SW.Serverless.Samples.Greedy\SW.Serverless.Samples.Greedy.csproj"
+                          ReferenceOutputAssembly="false" />
     </ItemGroup>
 
     <ItemGroup>

--- a/SW.Serverless.sln
+++ b/SW.Serverless.sln
@@ -45,6 +45,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SW.Serverless.Samples.Carri
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SW.Serverless.Samples.CarrierContract", "SW.Serverless.Samples.CarrierContract\SW.Serverless.Samples.CarrierContract.csproj", "{89099FF5-6D08-481C-A2F8-E9B5A62DA091}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SW.Serverless.Samples.Greedy", "SW.Serverless.Samples.Greedy\SW.Serverless.Samples.Greedy.csproj", "{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -271,6 +273,18 @@ Global
 		{89099FF5-6D08-481C-A2F8-E9B5A62DA091}.Release|x64.Build.0 = Release|Any CPU
 		{89099FF5-6D08-481C-A2F8-E9B5A62DA091}.Release|x86.ActiveCfg = Release|Any CPU
 		{89099FF5-6D08-481C-A2F8-E9B5A62DA091}.Release|x86.Build.0 = Release|Any CPU
+		{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}.Debug|x64.Build.0 = Debug|Any CPU
+		{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}.Debug|x86.Build.0 = Debug|Any CPU
+		{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}.Release|x64.ActiveCfg = Release|Any CPU
+		{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}.Release|x64.Build.0 = Release|Any CPU
+		{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}.Release|x86.ActiveCfg = Release|Any CPU
+		{BF14E99D-641B-4FF8-9626-F16FE2FD42DA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SW.Serverless/Resident/AdapterCommand.cs
+++ b/SW.Serverless/Resident/AdapterCommand.cs
@@ -1,0 +1,38 @@
+using System;
+
+namespace SW.Serverless.Resident
+{
+    /// <summary>
+    /// One command an adapter exposes, in enough detail to call it without reading its source.
+    ///
+    /// The names alone have always been available. What was missing is the shape — whether a
+    /// command takes an argument, what that argument looks like, and whether anything comes back —
+    /// which is the difference between knowing an adapter has a "Discover" method and being able
+    /// to offer it to an operator.
+    /// </summary>
+    public class AdapterCommand
+    {
+        public string Name { get; set; }
+
+        /// <summary>The argument's type name, or empty when the command takes none.</summary>
+        public string ParameterType { get; set; }
+
+        /// <summary>
+        /// A complex argument's public properties as a JSON object of name to type, so a caller
+        /// can build a form for a command it has never seen. Empty for a primitive or absent
+        /// argument, where <see cref="ParameterType"/> already says everything.
+        /// </summary>
+        public string ParameterSchema { get; set; }
+
+        /// <summary>False for a command returning Task rather than Task&lt;T&gt;.</summary>
+        public bool ReturnsValue { get; set; }
+
+        /// <summary>From [AdapterCommand] on the method, when the author set one.</summary>
+        public string Description { get; set; }
+
+        public bool TakesArgument => !string.IsNullOrEmpty(ParameterType);
+
+        public override string ToString() =>
+            $"{Name}({ParameterType}){(ReturnsValue ? "" : " -> void")}";
+    }
+}

--- a/SW.Serverless/Resident/AdapterHostService.cs
+++ b/SW.Serverless/Resident/AdapterHostService.cs
@@ -46,6 +46,18 @@ namespace SW.Serverless.Resident
                 .Select(c => c["command:".Length..])
                 .OrderBy(c => c)
                 .ToArray();
+            instance.CommandDetails = first.Hello.Commands
+                .Select(c => new AdapterCommand
+                {
+                    Name = c.Name,
+                    ParameterType = c.ParameterType,
+                    ParameterSchema = c.ParameterSchema,
+                    ReturnsValue = c.ReturnsValue,
+                    Description = c.Description
+                })
+                .OrderBy(c => c.Name)
+                .ToArray();
+
             instance.SdkVersion = first.Hello.SdkVersion;
             instance.ProtocolVersion = first.Hello.ProtocolVersion;
 

--- a/SW.Serverless/Resident/AdapterSpec.cs
+++ b/SW.Serverless/Resident/AdapterSpec.cs
@@ -30,5 +30,15 @@ namespace SW.Serverless.Resident
 
         public long SoftMemoryLimitBytes { get; set; }
         public long HardMemoryLimitBytes { get; set; }
+
+        /// <summary>
+        /// Sustained CPU ceiling as a percentage of the whole machine. Zero uses the host default. See
+        /// <see cref="ResourceLimits.CpuPercentLimit"/> for why it is sustained rather than
+        /// instantaneous.
+        /// </summary>
+        public double CpuPercentLimit { get; set; }
+
+        /// <summary>Consecutive over-limit samples before the CPU ceiling trips. Zero uses the host default.</summary>
+        public int CpuLimitSamples { get; set; }
     }
 }

--- a/SW.Serverless/Resident/IResidentAdapterHost.cs
+++ b/SW.Serverless/Resident/IResidentAdapterHost.cs
@@ -35,6 +35,26 @@ namespace SW.Serverless.Resident
         Task StopAsync(string adapterId, string instanceKey, bool drain = true, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Changes the ceilings a running adapter is held to.
+        ///
+        /// The soft memory and CPU ceilings are read on every sample, so they are in force
+        /// immediately. The hard memory ceiling is the runtime's own GC heap limit and is fixed at
+        /// launch, so a change to it is reported as needing a restart rather than quietly ignored —
+        /// the caller decides whether that happens now or at a quieter moment.
+        /// </summary>
+        Task<LimitUpdate> UpdateLimitsAsync(string adapterId, string instanceKey,
+            ResourceLimits limits, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Relaunches an instance in place, keeping its registry entry — so a lease, a data source,
+        /// or anything else holding the key still points at it afterwards. Stopping and starting
+        /// instead drops the entry, which in Bitween's case would release the broker lease that
+        /// makes the connection exclusive.
+        /// </summary>
+        Task<ResidentAdapterInstance> RestartAsync(string adapterId, string instanceKey,
+            bool drain = true, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Check out one warm instance from a pool of stateless workers. Replaces a per-invocation
         /// process spawn. Only for adapters declaring Poolable — a process-static field would
         /// otherwise leak across sessions (design doc 14.5).

--- a/SW.Serverless/Resident/InstanceHealth.cs
+++ b/SW.Serverless/Resident/InstanceHealth.cs
@@ -38,6 +38,14 @@ namespace SW.Serverless.Resident
         // Advertised by the adapter on attach
         public IReadOnlyCollection<string> Capabilities { get; set; } = Array.Empty<string>();
         public IReadOnlyCollection<string> Commands { get; set; } = Array.Empty<string>();
+
+        /// <summary>
+        /// The commands with their shapes — argument type, argument schema, whether anything is
+        /// returned. Empty for an adapter built against an older SDK, where <see cref="Commands"/>
+        /// still carries the names.
+        /// </summary>
+        public IReadOnlyCollection<AdapterCommand> CommandDetails { get; set; }
+            = Array.Empty<AdapterCommand>();
         public string SdkVersion { get; set; }
         public int ProtocolVersion { get; set; }
         public IReadOnlyDictionary<string, string> StartupValues { get; set; }

--- a/SW.Serverless/Resident/ResidentAdapterHost.cs
+++ b/SW.Serverless/Resident/ResidentAdapterHost.cs
@@ -453,6 +453,7 @@ namespace SW.Serverless.Resident
                 LastHeartbeatOn = supervised.LastHeartbeatOn,
                 Capabilities = instance.Capabilities,
                 Commands = instance.Commands,
+                CommandDetails = instance.CommandDetails,
                 SdkVersion = instance.SdkVersion,
                 ProtocolVersion = instance.ProtocolVersion,
                 StartupValues = instance.StartupValues,

--- a/SW.Serverless/Resident/ResidentAdapterHost.cs
+++ b/SW.Serverless/Resident/ResidentAdapterHost.cs
@@ -239,6 +239,7 @@ namespace SW.Serverless.Resident
             supervised.MissedHeartbeats = 0;
             supervised.DrainRequested = false;
             supervised.LastCpuSampleOn = null;
+            supervised.CpuOverSamples = 0;
             _ = instance.DisposeAsync().AsTask();
 
             if (supervised.Quarantined)
@@ -264,6 +265,92 @@ namespace SW.Serverless.Resident
                     logger.LogError(ex, "Restart of {AdapterId} failed.", instance.AdapterId);
                 }
             });
+        }
+
+        public Task<LimitUpdate> UpdateLimitsAsync(string adapterId, string instanceKey,
+            ResourceLimits limits, CancellationToken cancellationToken = default)
+        {
+            if (limits == null) throw new ArgumentNullException(nameof(limits));
+
+            if (!instances.TryGetValue(Key(adapterId, instanceKey), out var supervised))
+                return Task.FromResult(new LimitUpdate { Applied = false, Reason = "No such instance." });
+
+            var spec = supervised.Spec;
+            var hardChanged = limits.HardMemoryLimitBytes != spec.HardMemoryLimitBytes;
+
+            spec.SoftMemoryLimitBytes = limits.SoftMemoryLimitBytes;
+            spec.HardMemoryLimitBytes = limits.HardMemoryLimitBytes;
+            spec.CpuPercentLimit = limits.CpuPercentLimit;
+            spec.CpuLimitSamples = limits.CpuLimitSamples;
+
+            // A lowered CPU ceiling should not trip on a streak the adapter accumulated under the
+            // old one — that would recycle it for something it did before the rule existed.
+            supervised.CpuOverSamples = 0;
+
+            logger.LogInformation("Adapter {AdapterId}/{InstanceKey} limits set to {Limits}.",
+                adapterId, instanceKey, limits);
+
+            return Task.FromResult(new LimitUpdate
+            {
+                Applied = true,
+                Limits = limits,
+                // The soft and CPU ceilings are read from the spec on every sample, so they are
+                // already in force. The hard one was handed to the runtime as a GC heap limit when
+                // the process launched, and nothing can change that in place.
+                RestartRequired = hardChanged && limits.HardMemoryLimitBytes > 0,
+                Reason = hardChanged && limits.HardMemoryLimitBytes > 0
+                    ? "The hard memory ceiling is the runtime's own GC heap limit, set when the "
+                      + "process launched. It applies from the next restart."
+                    : null,
+            });
+        }
+
+        public async Task<ResidentAdapterInstance> RestartAsync(string adapterId, string instanceKey,
+            bool drain = true, CancellationToken cancellationToken = default)
+        {
+            if (!instances.TryGetValue(Key(adapterId, instanceKey), out var supervised))
+                throw new InvalidOperationException(
+                    $"No resident adapter '{adapterId}' with instance key '{instanceKey}' is running here.");
+
+            // Relaunch in place: the entry stays in the registry under the same key, so whatever
+            // owns this instance — a lease, a data source, a caller holding the key — still points
+            // at it afterwards. Stopping and starting instead would drop the entry and, in
+            // Bitween's case, release the broker lease that makes the connection exclusive.
+            //
+            // Stopping is set for the teardown so the exit does not look like a crash and trigger
+            // the backoff restart; this method does the relaunch itself.
+            supervised.Stopping = true;
+            try
+            {
+                var old = supervised.Instance;
+                if (old != null)
+                {
+                    old.RequestShutdown("restart requested", drain);
+                    var deadline = drain ? TimeSpan.FromSeconds(30) : TimeSpan.FromSeconds(5);
+                    if (old.Process != null && !old.Process.HasExited)
+                        await Task.Run(() => old.Process.WaitForExit((int)deadline.TotalMilliseconds),
+                            cancellationToken);
+
+                    TryKill(old.Process);
+                    await old.DisposeAsync();
+                }
+
+                supervised.MissedHeartbeats = 0;
+                supervised.DrainRequested = false;
+                supervised.LastCpuSampleOn = null;
+                supervised.CpuOverSamples = 0;
+            }
+            finally
+            {
+                supervised.Stopping = false;
+            }
+
+            await SpawnAsync(supervised, cancellationToken);
+
+            logger.LogInformation("Adapter {AdapterId}/{InstanceKey} restarted on request.",
+                adapterId, instanceKey);
+
+            return supervised.Instance;
         }
 
         public async Task StopAsync(string adapterId, string instanceKey, bool drain = true,
@@ -327,7 +414,11 @@ namespace SW.Serverless.Resident
             StartupValues = spec.StartupValues,
             AdapterValues = spec.AdapterValues,
             SoftMemoryLimitBytes = spec.SoftMemoryLimitBytes,
-            HardMemoryLimitBytes = spec.HardMemoryLimitBytes
+            HardMemoryLimitBytes = spec.HardMemoryLimitBytes,
+            // Easy to miss, and silent when missed: a pooled adapter would run with the memory
+            // ceilings its spec asked for and no CPU ceiling at all.
+            CpuPercentLimit = spec.CpuPercentLimit,
+            CpuLimitSamples = spec.CpuLimitSamples
         };
 
         // ------------------------------------------------------------------ lookups
@@ -462,6 +553,31 @@ namespace SW.Serverless.Resident
                     ? supervised.Spec.SoftMemoryLimitBytes : options.SoftMemoryLimitBytes;
                 var hard = supervised.Spec.HardMemoryLimitBytes > 0
                     ? supervised.Spec.HardMemoryLimitBytes : options.HardMemoryLimitBytes;
+                var cpuLimit = supervised.Spec.CpuPercentLimit > 0
+                    ? supervised.Spec.CpuPercentLimit : options.CpuPercentLimit;
+                var cpuSamples = supervised.Spec.CpuLimitSamples > 0
+                    ? supervised.Spec.CpuLimitSamples : Math.Max(1, options.CpuLimitSamples);
+
+                // CPU is judged over consecutive samples, never on one. An adapter draining a
+                // backlog is supposed to peg a core; only a run of samples separates that from a
+                // loop that will never stop. The first sample after a launch has no elapsed wall
+                // time behind it, so it is not counted.
+                if (cpuLimit > 0 && supervised.CpuPercent > 0)
+                {
+                    if (supervised.CpuPercent > cpuLimit) supervised.CpuOverSamples++;
+                    else supervised.CpuOverSamples = 0;
+
+                    if (supervised.CpuOverSamples >= cpuSamples && !supervised.DrainRequested)
+                    {
+                        supervised.DrainRequested = true;
+                        supervised.CpuOverSamples = 0;
+                        logger.LogWarning(
+                            "Adapter {AdapterId}/{InstanceKey} held {Cpu}% CPU across {Samples} samples (limit {Limit}%); asking it to drain.",
+                            instance.AdapterId, instance.InstanceKey, supervised.CpuPercent, cpuSamples, cpuLimit);
+                        instance.RequestShutdown("sustained cpu limit", drain: true);
+                        return;
+                    }
+                }
 
                 // Soft first: draining lets in-flight messages be nacked. A hard kill cannot.
                 if (soft > 0 && rss > soft && !supervised.DrainRequested)
@@ -504,6 +620,9 @@ namespace SW.Serverless.Resident
             public int LastThreadCount;
             public double CpuPercent;
             public TimeSpan LastCpu;
+
+            /// <summary>Consecutive samples above the CPU ceiling. Reset by any sample under it.</summary>
+            public int CpuOverSamples;
             public DateTimeOffset? LastCpuSampleOn;
             public DateTimeOffset? LastHeartbeatOn;
             readonly List<DateTimeOffset> crashes = new();

--- a/SW.Serverless/Resident/ResidentAdapterInstance.cs
+++ b/SW.Serverless/Resident/ResidentAdapterInstance.cs
@@ -76,6 +76,14 @@ namespace SW.Serverless.Resident
 
         public IReadOnlyCollection<string> Commands { get; internal set; } = Array.Empty<string>();
 
+        /// <summary>
+        /// The same commands with their shapes. Empty for an adapter built against an SDK from
+        /// before command descriptors existed — <see cref="Commands"/> still carries the names, so
+        /// an older adapter degrades to what was always there rather than to nothing.
+        /// </summary>
+        public IReadOnlyCollection<AdapterCommand> CommandDetails { get; internal set; }
+            = Array.Empty<AdapterCommand>();
+
         public string SdkVersion { get; internal set; }
         public int ProtocolVersion { get; internal set; }
         public IReadOnlyDictionary<string, string> AdapterValues { get; internal set; }

--- a/SW.Serverless/Resident/ResidentOptions.cs
+++ b/SW.Serverless/Resident/ResidentOptions.cs
@@ -31,6 +31,19 @@ namespace SW.Serverless.Resident
         public long SoftMemoryLimitBytes { get; set; } = 0;
         public long HardMemoryLimitBytes { get; set; } = 0;
 
+        /// <summary>
+        /// Sustained CPU ceiling as a percentage of the whole machine, applied to any adapter that does not
+        /// set its own. Off by default: a ceiling guessed on the host's behalf would recycle
+        /// whichever adapter happens to work hardest.
+        /// </summary>
+        public double CpuPercentLimit { get; set; } = 0;
+
+        /// <summary>
+        /// Consecutive samples above the CPU ceiling before it trips. Four heartbeats is long
+        /// enough that draining a backlog does not look like a runaway loop.
+        /// </summary>
+        public int CpuLimitSamples { get; set; } = 4;
+
         /// <summary>Workstation GC by default: server GC costs a heap and a thread per core.</summary>
         public bool UseWorkstationGc { get; set; } = true;
     }

--- a/SW.Serverless/Resident/ResourceLimits.cs
+++ b/SW.Serverless/Resident/ResourceLimits.cs
@@ -1,0 +1,84 @@
+using System;
+
+namespace SW.Serverless.Resident
+{
+    /// <summary>
+    /// The ceilings one adapter process runs under.
+    ///
+    /// An adapter is a separate process the host does not otherwise constrain, so without these a
+    /// single runaway payload is bounded by nothing but the machine — and every other adapter on
+    /// the node goes down with it. Zero on any field means "leave the host default alone", which is
+    /// how a caller changes one ceiling without having to restate the others.
+    /// </summary>
+    public class ResourceLimits
+    {
+        /// <summary>
+        /// Soft RSS ceiling in bytes. Crossing it asks the adapter to DRAIN — finish what is in
+        /// flight, then exit — so nothing is lost and the supervisor relaunches it. This is the
+        /// ceiling that should normally fire.
+        /// </summary>
+        public long SoftMemoryLimitBytes { get; set; }
+
+        /// <summary>
+        /// Hard RSS ceiling in bytes. Crossing it kills the process tree, and it is also handed to
+        /// the runtime as DOTNET_GCHeapHardLimit so an allocation past it fails inside the adapter
+        /// rather than taking the node with it.
+        ///
+        /// Because the runtime reads it at launch, changing this one only takes effect on a
+        /// restart — see <see cref="LimitUpdate.RestartRequired"/>.
+        /// </summary>
+        public long HardMemoryLimitBytes { get; set; }
+
+        /// <summary>
+        /// Sustained CPU ceiling, as a percentage of the WHOLE machine — the same figure
+        /// <see cref="InstanceHealth.CpuPercent"/> reports, which is processor time divided by
+        /// wall time divided by <see cref="Environment.ProcessorCount"/>.
+        ///
+        /// Worth being exact about, because the intuitive reading is wrong in an expensive
+        /// direction: one core pegged flat out on a sixteen-core host reads about 6%, so a ceiling
+        /// set at "50%, surely that's half a core" would in fact allow eight cores.
+        ///
+        /// Deliberately sustained rather than instantaneous: an adapter draining a backlog is
+        /// SUPPOSED to peg a core, and recycling it for doing its job well would be a bug wearing a
+        /// limit's clothes. It trips only after <see cref="CpuLimitSamples"/> consecutive samples
+        /// above the line, and then asks for a drain — there is no hard CPU kill, because killing
+        /// on CPU punishes throughput rather than protecting the node.
+        /// </summary>
+        public double CpuPercentLimit { get; set; }
+
+        /// <summary>
+        /// Consecutive over-limit samples before the CPU ceiling trips. Zero uses the host default.
+        /// Samples are taken on the heartbeat, so this is a multiple of the heartbeat interval.
+        /// </summary>
+        public int CpuLimitSamples { get; set; }
+
+        public bool IsEmpty =>
+            SoftMemoryLimitBytes <= 0 && HardMemoryLimitBytes <= 0 && CpuPercentLimit <= 0;
+
+        public override string ToString() =>
+            $"soft={Mb(SoftMemoryLimitBytes)} hard={Mb(HardMemoryLimitBytes)} cpu={(CpuPercentLimit > 0 ? CpuPercentLimit + "%" : "—")}";
+
+        static string Mb(long bytes) => bytes > 0 ? $"{bytes / 1024 / 1024}MB" : "—";
+    }
+
+    /// <summary>What changing an adapter's limits actually did.</summary>
+    public class LimitUpdate
+    {
+        /// <summary>False when there is no such instance to change.</summary>
+        public bool Applied { get; set; }
+
+        /// <summary>
+        /// True when part of the change cannot take effect until the process is relaunched. The
+        /// hard memory ceiling is the one that does this: the runtime reads it at launch. The
+        /// caller decides whether to restart now or at a quieter moment — which is the whole
+        /// reason this is reported rather than acted on.
+        /// </summary>
+        public bool RestartRequired { get; set; }
+
+        /// <summary>Why a restart is needed, in words an operator can act on.</summary>
+        public string Reason { get; set; }
+
+        /// <summary>The ceilings now in force on the supervised spec.</summary>
+        public ResourceLimits Limits { get; set; }
+    }
+}


### PR DESCRIPTION
Three gaps in the resident-adapter runtime, found while wiring external bus providers into Bitween. **73 tests pass** (54 before).

## 1. The memory ceilings were enforced and covered by nothing

`ResidentAdapterHost` samples RSS and acts — soft limit asks the adapter to drain, hard limit kills the process tree — and not one test touched it. An adapter is a separate process the host does not otherwise constrain, so these limits are the difference between one integration failing and the whole node failing.

Now tested against a **real** process: a new `Greedy` sample allocates real memory and burns a real core on command, because the watchdog samples the operating system. A fake would prove only that the test agrees with itself.

## 2. CPU was sampled and never acted on

There was no CPU ceiling at all. Added one, and it is **sustained rather than instantaneous** on purpose: an adapter draining a backlog is *supposed* to peg a core, and recycling it for working hard would be a bug wearing a limit's clothes. It trips only after N consecutive samples and then asks for a drain — there is no hard CPU kill, because killing on CPU punishes throughput rather than protecting the node.

The metric's documentation was also ambiguous in an expensive direction. `CpuPercent` divides by `ProcessorCount`, so one core pegged flat out on a sixteen-core host reads about **6%** — meaning a ceiling set at "50%, surely that's half a core" would in fact allow eight. Now stated explicitly.

## 3. Limits could not be changed on a running adapter

Callers stopped and started. In Bitween that releases the broker lease making a connection exclusive, so a limit change would briefly become a handover.

- **`UpdateLimitsAsync`** — soft memory and CPU are read on every sample, so they apply immediately. The hard ceiling is the runtime's own GC heap limit, fixed at launch, so a change to it is **reported** as `RestartRequired` rather than accepted and quietly ignored — which is the failure an operator could not possibly detect.
- **`RestartAsync`** — relaunches under the same registry key, so a lease or data source holding that key still points at it.

Also fixed `CloneWithKey` silently dropping the CPU fields: a **pooled** adapter would have run with the memory ceilings it asked for and no CPU ceiling at all.

## 4. Adapter commands are now discoverable by shape, not just name

The host knew command *names*. It could not say whether one takes an argument, what that argument looks like, or whether anything comes back — so anything wanting to offer them had to hard-code them.

`Hello` gains `repeated CommandInfo commands` (name, parameter type, parameter schema, returns-value, description). `capabilities` is untouched, so an adapter or host from before this degrades to the names it always had. `[AdapterCommand("…")]` adds a line of prose — optional, but the difference between a list of names and a list an operator can act on.

The test that makes the rest worth anything: **a command invoked from its declared shape alone**, with the argument built from the schema rather than from knowledge of the type.

## Two things worth reading in the diff

The hard-ceiling test asserts the runtime refuses the allocation with `OutOfMemoryException` **before the watchdog's kill is needed** — the containment working at its best, and better than I first assumed.

The soft-ceiling update test *grows into* the new limit rather than sitting above it. Resident set size is not a number a process controls: the OS reclaims pages under pressure, so a static heap drifts back under the line and the test flakes. Growing into the ceiling tests the same behaviour without depending on the OS holding still.

🤖 Generated with [Claude Code](https://claude.com/claude-code)