### PR TITLE
README: how a resident adapter works

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,133 @@ class Program
 }
 ```
 
+## Resident Adapters
+
+A classic adapter is launched per invocation and exits when it returns. A **resident** adapter is
+launched once and stays running, so it can hold state — an open broker connection, a pooled HTTP/2
+channel, a warm cache — and push work into the host as well as receive it.
+
+```mermaid
+sequenceDiagram
+    participant H as Host
+    participant S as Cloud storage
+    participant A as Adapter process
+
+    H->>S: fetch + extract by adapter id
+    H->>A: launch, with memory and CPU ceilings
+    A->>H: dial back over UDS / named pipe (gRPC)
+    A->>H: Hello — commands, capabilities, SDK version
+
+    Note over H,A: process stays up
+
+    loop while running
+        H->>A: Invoke(command, argument)
+        A-->>H: result
+        A->>H: Publish(event)
+        H-->>A: accepted / rejected
+        H->>A: Ping
+        A-->>H: status, counters, last error
+    end
+
+    H->>A: Stop(drain)
+    A-->>H: finishes in flight, exits
+```
+
+The adapter dials **out** to the host over a Unix domain socket or a named pipe — nothing listens
+on a TCP port, and the adapter needs no inbound reachability.
+
+### Two directions
+
+| | |
+| --- | --- |
+| **Host → adapter** | `InvokeAsync<T>("Command", argument)` — any public `Task`/`Task<T>` method on the handler, discovered by reflection. |
+| **Adapter → host** | `context.PublishAsync(payload, dedupeKey, endpoint, …)` — the host persists, then answers accepted or rejected. The adapter acknowledges its source only after that. |
+
+### Writing one
+
+```csharp
+using SW.Serverless.Sdk;
+using SW.Serverless.Sdk.Resident;
+
+class Handler : IResidentAdapter
+{
+    IAdapterContext _context;
+
+    public Task StartAsync(IAdapterContext context, CancellationToken ct)
+    {
+        _context = context;                       // connect, subscribe, warm up
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+
+    public Task<AdapterStatus> GetStatusAsync() =>
+        Task.FromResult(new AdapterStatus { Connected = true, State = "Ready" });
+
+    [AdapterCommand("What this command does.")]
+    public Task<object> GetStats() => Task.FromResult<object>(new { ok = true });
+}
+
+class Program
+{
+    static Task Main() => Runner.RunResident(new Handler());
+}
+```
+
+Host side:
+
+```csharp
+services.AddResidentAdapters<MyEventSink>(o =>
+{
+    o.HeartbeatInterval = TimeSpan.FromSeconds(15);
+    o.SoftMemoryLimitBytes = 512L * 1024 * 1024;
+});
+
+var instance = await adapters.StartExclusiveAsync(new AdapterSpec
+{
+    AdapterId = "my.adapter",
+    InstanceKey = "1",
+    StartupValues = { ["Host"] = "broker.example.com" },
+});
+```
+
+### Supervision
+
+The host samples each adapter process on every heartbeat and acts on what it finds.
+
+```mermaid
+flowchart LR
+    Sample[Heartbeat sample] --> Check{What did it find?}
+    Check -- healthy --> Sample
+    Check -- over soft memory or CPU --> Drain[Ask to drain, relaunch]
+    Check -- over hard memory --> Kill[Kill process tree, relaunch]
+    Check -- no answer --> Miss[Restart after N misses]
+    Drain --> Quarantine[Repeated crashes: quarantine]
+    Kill --> Quarantine
+    Miss --> Quarantine
+```
+
+| Control | Effect |
+| --- | --- |
+| `SoftMemoryLimitBytes` | Asks the adapter to drain — in-flight work finishes, nothing is lost. |
+| `HardMemoryLimitBytes` | Kills the process tree, and is applied to the runtime as `DOTNET_GCHeapHardLimit`. |
+| `CpuPercentLimit` + `CpuLimitSamples` | Trips after N consecutive samples above the line, then asks to drain. The figure is a share of the whole machine, not of one core. |
+| `UpdateLimitsAsync` | Changes ceilings on a running adapter. Soft and CPU apply on the next sample; a hard-memory change reports `RestartRequired`. |
+| `RestartAsync` | Relaunches in place, keeping the instance key. |
+
+### Discovery
+
+Every public `Task`/`Task<T>` method on a handler is a command. The adapter reports them on attach,
+with the shape needed to call one:
+
+```csharp
+foreach (var c in adapters.Describe().Single(h => h.InstanceKey == "1").CommandDetails)
+    Console.WriteLine($"{c.Name}({c.ParameterType}) {c.ParameterSchema} — {c.Description}");
+```
+
+`ParameterSchema` lists a complex argument's properties as name → type, so a caller can build a form
+for a command it has not seen before.
+
 ## Features
 
 - **Process Isolation**: Each adapter runs in its own process with timeout management


### PR DESCRIPTION
The README covered only the classic per-invocation model — resident adapters were not mentioned at all, despite being most of what the runtime now does.

Adds a **Resident Adapters** section: two diagrams, the handler shape, the host wiring, the resource controls, and command discovery.

Mechanics only — what it does and how to use it, not how the design got there. The reasoning already lives in `docs/resident-adapters-design.md`.

### Lifecycle

```mermaid
sequenceDiagram
    participant H as Host
    participant S as Cloud storage
    participant A as Adapter process

    H->>S: fetch + extract by adapter id
    H->>A: launch, with memory and CPU ceilings
    A->>H: dial back over UDS / named pipe (gRPC)
    A->>H: Hello — commands, capabilities, SDK version

    Note over H,A: process stays up

    loop while running
        H->>A: Invoke(command, argument)
        A-->>H: result
        A->>H: Publish(event)
        H-->>A: accepted / rejected
        H->>A: Ping
        A-->>H: status, counters, last error
    end

    H->>A: Stop(drain)
    A-->>H: finishes in flight, exits
```

### Supervision

```mermaid
flowchart LR
    Sample[Heartbeat sample] --> Check{What did it find?}
    Check -- healthy --> Sample
    Check -- over soft memory or CPU --> Drain[Ask to drain, relaunch]
    Check -- over hard memory --> Kill[Kill process tree, relaunch]
    Check -- no answer --> Miss[Restart after N misses]
    Drain --> Quarantine[Repeated crashes: quarantine]
    Kill --> Quarantine
    Miss --> Quarantine
```

Both diagrams were rendered before committing rather than assumed to parse, and the adapter code sample **compiles verbatim** against the SDK — checked in a scratch project, not by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)