### PR TITLE
Let the WPF desktop project restore on macOS and Linux

### DIFF
--- a/SW.Serverless.Desktop/SW.Serverless.Desktop.csproj
+++ b/SW.Serverless.Desktop/SW.Serverless.Desktop.csproj
@@ -5,6 +5,9 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>icon.ico</ApplicationIcon>
+    <!-- Lets the project restore and build on macOS and Linux, so it can be opened alongside the
+         rest of the solution. A no-op on Windows, where it is the default. -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
One line. Without `EnableWindowsTargeting`, `SW.Serverless.Desktop` fails to restore off Windows with **NETSDK1100**, so any solution containing it cannot be built there at all.

It is a no-op on Windows, where it is already the default. Verified the project builds on macOS with it set.

Came up while adding every project across the repos to the monorepo's `BitweenAll.sln` — this project was the only thing stopping that solution from building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)