### PR TITLE
Installer stamps kind and lifecycle, and publishes to every provider

### DIFF
--- a/SW.Serverless.Installer.UnitTests/AdapterDescriberTests.cs
+++ b/SW.Serverless.Installer.UnitTests/AdapterDescriberTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SW.Serverless.Installer.Shared;
+
+namespace SW.Serverless.Installer.UnitTests;
+
+/// <summary>
+/// What the installer stamps onto an adapter at publish time.
+///
+/// Before this, a host learned an adapter's kind from a naming convention baked into its id, and
+/// its lifecycle not at all — so a resident adapter looked exactly like a classic one and could be
+/// offered somewhere it could never run. Reading both from the assembly means the answer comes from
+/// the code rather than from whoever typed the id.
+///
+/// These read REAL sample adapters, built by the solution, rather than a fixture assembly written
+/// to agree with the describer.
+/// </summary>
+[TestClass]
+public class AdapterDescriberTests
+{
+    /// <summary>
+    /// The samples are built beside the tests, so their published output is next door rather than
+    /// somewhere this has to be told about.
+    /// </summary>
+    private static string SampleDirectory(string projectName)
+    {
+        var here = Path.GetDirectoryName(typeof(AdapterDescriberTests).Assembly.Location)!;
+
+        // …/SW.Serverless.Installer.UnitTests/bin/Debug/net8.0 → …/<project>/bin/Debug/<tfm>
+        var repo = Path.GetFullPath(Path.Combine(here, "..", "..", "..", ".."));
+        var bin = Path.Combine(repo, projectName, "bin");
+        if (!Directory.Exists(bin)) return null;
+
+        return Directory.GetDirectories(bin, "*", SearchOption.AllDirectories)
+            .FirstOrDefault(d => File.Exists(Path.Combine(d, projectName + ".dll")));
+    }
+
+    [TestMethod]
+    public void A_resident_adapter_is_described_as_resident()
+    {
+        var directory = SampleDirectory("SW.Serverless.Samples.Greedy");
+        Assert.IsNotNull(directory, "the Greedy sample was not built beside the tests");
+
+        var description = AdapterDescriber.Describe(directory, "SW.Serverless.Samples.Greedy.dll");
+
+        Assert.AreEqual(AdapterDescription.ResidentLifecycle, description.Lifecycle);
+    }
+
+    /// <summary>
+    /// And a classic one is not. Without this the lifecycle check could be returning "resident"
+    /// for everything and every test above would still pass.
+    /// </summary>
+    [TestMethod]
+    public void A_classic_adapter_is_described_as_classic()
+    {
+        var directory = SampleDirectory("SW.Serverless.Samples.Classic");
+        Assert.IsNotNull(directory, "the Classic sample was not built beside the tests");
+
+        var description = AdapterDescriber.Describe(directory, "SW.Serverless.Samples.Classic.dll");
+
+        Assert.AreEqual(AdapterDescription.ClassicLifecycle, description.Lifecycle);
+    }
+
+    /// <summary>
+    /// The roles an adapter declares reach the metadata, so a host can offer it in the right place
+    /// without the kind being encoded in its id — and can reclassify it later without a rename,
+    /// which is not free when every configuration stores that id.
+    /// </summary>
+    [TestMethod]
+    public void The_kinds_an_adapter_declares_are_read()
+    {
+        var directory = SampleDirectory("SW.Serverless.Samples.Classic");
+        var description = AdapterDescriber.Describe(directory, "SW.Serverless.Samples.Classic.dll");
+
+        // Declared twice on the handler; both come through, sorted so the value is stable.
+        Assert.AreEqual("handler,mapper", description.Kind);
+    }
+
+    /// <summary>
+    /// An adapter that declares nothing gets no kind. Guessing one would put it in a menu where
+    /// choosing it cannot work, which is the failure this whole change exists to remove.
+    /// </summary>
+    [TestMethod]
+    public void An_adapter_that_declares_no_kind_gets_none()
+    {
+        var directory = SampleDirectory("SW.Serverless.Samples.Greedy");
+        var description = AdapterDescriber.Describe(directory, "SW.Serverless.Samples.Greedy.dll");
+
+        Assert.AreEqual("", description.Kind);
+    }
+
+    /// <summary>
+    /// A publish must not fail because the description could not be read, so anything unreadable
+    /// describes as the classic, kind-less adapter every adapter was before this existed.
+    /// </summary>
+    [TestMethod]
+    public void A_missing_assembly_describes_as_classic_rather_than_throwing()
+    {
+        var description = AdapterDescriber.Describe(
+            Path.GetTempPath(), $"not-here-{Guid.NewGuid():N}.dll");
+
+        Assert.AreEqual(AdapterDescription.ClassicLifecycle, description.Lifecycle);
+        Assert.AreEqual("", description.Kind);
+    }
+
+    [TestMethod]
+    public void A_missing_directory_describes_as_classic_rather_than_throwing()
+    {
+        var description = AdapterDescriber.Describe(
+            Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N")), "anything.dll");
+
+        Assert.AreEqual(AdapterDescription.ClassicLifecycle, description.Lifecycle);
+    }
+
+    /// <summary>Every provider the tool accepts is named in one place, so help and errors agree.</summary>
+    [TestMethod]
+    public void Every_storage_provider_is_offered()
+    {
+        CollectionAssert.AreEquivalent(
+            new[] { "s3", "as", "oc", "gc", "local" },
+            CloudFilesFactory.Providers.ToList());
+    }
+
+    [TestMethod]
+    public void An_unknown_storage_provider_is_a_clear_error()
+    {
+        var error = Assert.ThrowsException<SW.PrimitiveTypes.SWException>(
+            () => CloudFilesFactory.Create(new ServerlessUploadOptions { Provider = "dropbox" }));
+
+        StringAssert.Contains(error.Message, "dropbox");
+        StringAssert.Contains(error.Message, "gc");
+    }
+}

--- a/SW.Serverless.Installer.UnitTests/SW.Serverless.Installer.UnitTests.csproj
+++ b/SW.Serverless.Installer.UnitTests/SW.Serverless.Installer.UnitTests.csproj
@@ -20,6 +20,12 @@
 
     <ItemGroup>
       <ProjectReference Include="..\SW.Serverless.Installer\SW.Serverless.Installer.csproj" />
+      <!-- Build order only: these are READ as assemblies, to prove the describer reads a real
+           adapter rather than a hand-made fixture. -->
+      <ProjectReference Include="..\SW.Serverless.Samples.Greedy\SW.Serverless.Samples.Greedy.csproj"
+                        ReferenceOutputAssembly="false" />
+      <ProjectReference Include="..\SW.Serverless.Samples.Classic\SW.Serverless.Samples.Classic.csproj"
+                        ReferenceOutputAssembly="false" />
     </ItemGroup>
 
 </Project>

--- a/SW.Serverless.Installer/Options.cs
+++ b/SW.Serverless.Installer/Options.cs
@@ -15,8 +15,13 @@ namespace SW.Serverless.Installer
     {
         //[Option('v', "verbose", Required = false, HelpText = "Set output to verbose messages.")]
         //public bool Verbose { get; set; }
-        [Option('p', "provider", HelpText = "Provider for storage (as/s3/oc).")]
+        [Option('p', "provider", HelpText = "Storage provider: s3, as (Azure), oc (Oracle), gc (Google), or local (filesystem, for development).")]
         public string Provider { get; set; }
+
+        [Option('k', "kind",
+            HelpText = "Roles this adapter serves, comma separated (e.g. handler,mapper). " +
+                       "Only needed when the adapter does not declare them with [AdapterKind].")]
+        public string Kind { get; set; }
 
         [Option('a', "accesskey", HelpText = "Access key for storage.")]
         public string AccessKeyId { get; set; }
@@ -75,5 +80,19 @@ namespace SW.Serverless.Installer
 
         public string AdapterId { get; set; }
         public string NamespaceName { get; set; }
+
+        // ——— Google Cloud service account ———
+        public string ProjectId { get; set; }
+        public string PrivateKeyId { get; set; }
+        public string PrivateKey { get; set; }
+        public string ClientEmail { get; set; }
+        public string ClientId { get; set; }
+        public string ClientX509CertUrl { get; set; }
+
+        /// <summary>
+        /// Roles this adapter serves, comma separated. Overrides what the assembly declared, for
+        /// an adapter whose author has not added [AdapterKind] to it.
+        /// </summary>
+        public string Kind { get; set; }
     }
 }

--- a/SW.Serverless.Installer/Program.cs
+++ b/SW.Serverless.Installer/Program.cs
@@ -39,6 +39,7 @@ namespace SW.Serverless.Installer
                     Version = options.Version,
                     Provider = options.Provider,
                     AdapterId = options.AdapterId,
+                    Kind = options.Kind,
                 };
 
 
@@ -87,7 +88,18 @@ namespace SW.Serverless.Installer
                 var projectFileName = Path.GetFileName(opts.ProjectPath);
                 var entryAssembly = $"{projectFileName!.Remove(projectFileName.LastIndexOf('.'))}.dll";
 
-                if (!await installer.PushToCloud(zipFileName, entryAssembly, await GetServerlessUploadOptions(opts)))
+                // Read from the published assembly rather than asked for: the lifecycle is a fact
+                // about the code, and a host that has to be told it separately will eventually be
+                // told wrong — which is how a resident adapter ends up offered somewhere only a
+                // classic one can run.
+                var description = AdapterDescriber.Describe(tempPath, entryAssembly);
+
+                // An explicit --kind wins, for an adapter whose author has not declared one.
+                if (!string.IsNullOrWhiteSpace(opts.Kind)) description.Kind = opts.Kind.Trim();
+
+                var uploadOptions = await GetServerlessUploadOptions(opts);
+
+                if (!await installer.PushToCloud(zipFileName, entryAssembly, uploadOptions, description))
                     return;
 
                 if (!installer.Cleanup(tempPath)) return;

--- a/SW.Serverless.Installer/SW.Serverless.Installer.csproj
+++ b/SW.Serverless.Installer/SW.Serverless.Installer.csproj
@@ -9,9 +9,16 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="SimplyWorks.CloudFiles.AS" Version="5.0.29" />
-    <PackageReference Include="SimplyWorks.CloudFiles.S3" Version="8.0.1" />
-    <PackageReference Include="SimplyWorks.CloudFiles.OC" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageReference Include="SimplyWorks.CloudFiles.AS" Version="8.1.12" />
+    <PackageReference Include="SimplyWorks.CloudFiles.AS.Extensions" Version="8.1.12" />
+    <PackageReference Include="SimplyWorks.CloudFiles.GC.Extensions" Version="8.1.12" />
+    <PackageReference Include="SimplyWorks.CloudFiles.LocalTests.Extensions" Version="8.1.12" />
+    <PackageReference Include="SimplyWorks.CloudFiles.OC.Extensions" Version="8.1.12" />
+    <PackageReference Include="SimplyWorks.CloudFiles.S3" Version="8.1.12" />
+    <PackageReference Include="SimplyWorks.CloudFiles.OC" Version="8.1.12" />
+    <PackageReference Include="SimplyWorks.CloudFiles.S3.Extensions" Version="8.1.12" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="10.0.11" />
 
   </ItemGroup>
 

--- a/SW.Serverless.Installer/Shared/AdapterDescriber.cs
+++ b/SW.Serverless.Installer/Shared/AdapterDescriber.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace SW.Serverless.Installer.Shared
+{
+    /// <summary>
+    /// What an adapter IS, read from the assembly at publish time.
+    /// </summary>
+    public class AdapterDescription
+    {
+        /// <summary>"resident" when the adapter stays running, otherwise "classic".</summary>
+        public string Lifecycle { get; set; } = ClassicLifecycle;
+
+        /// <summary>
+        /// The roles the adapter declared, comma separated. Empty when it declared none — this
+        /// framework does not guess, because guessing wrong puts an adapter in a menu where
+        /// choosing it cannot work.
+        /// </summary>
+        public string Kind { get; set; } = "";
+
+        public const string ResidentLifecycle = "resident";
+        public const string ClassicLifecycle = "classic";
+    }
+
+    /// <summary>
+    /// Reads an adapter's lifecycle and declared kinds out of its compiled assembly.
+    ///
+    /// Both used to be things a host had to be told separately or infer from a naming convention,
+    /// and a convention cannot express lifecycle at all — which is how a resident adapter ends up
+    /// offered in a menu that can only run classic ones.
+    ///
+    /// Uses <see cref="MetadataLoadContext"/>, so the assembly is READ rather than loaded: nothing
+    /// in the adapter executes, no static constructor runs, and a publish cannot be made to do
+    /// anything by the code it is packaging.
+    /// </summary>
+    public static class AdapterDescriber
+    {
+        private const string ResidentInterface = "IResidentAdapter";
+        private const string KindAttribute = "AdapterKindAttribute";
+
+        /// <summary>
+        /// Describes the entry assembly inside <paramref name="publishDirectory"/>. Never throws:
+        /// a publish must not fail because the description could not be read, so an unreadable
+        /// assembly simply describes as a classic adapter with no declared kind — which is what
+        /// every adapter was before any of this existed.
+        /// </summary>
+        public static AdapterDescription Describe(string publishDirectory, string entryAssembly)
+        {
+            var description = new AdapterDescription();
+
+            try
+            {
+                var assemblyPath = Path.Combine(publishDirectory, entryAssembly);
+                if (!File.Exists(assemblyPath)) return description;
+
+                // Everything beside it, plus the runtime, so interface and attribute types resolve.
+                var assemblies = Directory.GetFiles(publishDirectory, "*.dll", SearchOption.AllDirectories)
+                    .Concat(Directory.GetFiles(
+                        Path.GetDirectoryName(typeof(object).Assembly.Location)!, "*.dll"))
+                    .Distinct()
+                    .ToList();
+
+                using var context = new MetadataLoadContext(new PathAssemblyResolver(assemblies));
+                var assembly = context.LoadFromAssemblyPath(assemblyPath);
+
+                var kinds = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+                foreach (var type in SafeTypes(assembly))
+                {
+                    if (Implements(type, ResidentInterface))
+                        description.Lifecycle = AdapterDescription.ResidentLifecycle;
+
+                    foreach (var kind in KindsOn(type)) kinds.Add(kind);
+                }
+
+                description.Kind = string.Join(",", kinds);
+            }
+            catch
+            {
+                // Described as classic with no kind, which is the behaviour that predates this.
+            }
+
+            return description;
+        }
+
+        private static IEnumerable<Type> SafeTypes(Assembly assembly)
+        {
+            try { return assembly.GetTypes(); }
+            // A type whose dependency is missing must not stop the rest being read.
+            catch (ReflectionTypeLoadException ex) { return ex.Types.Where(t => t != null); }
+            catch { return Array.Empty<Type>(); }
+        }
+
+        /// <summary>
+        /// Matched by NAME rather than by type identity: the installer packages assemblies built
+        /// against whichever SDK version the author used, and a type loaded through a metadata
+        /// context is never reference-equal to the one this tool was compiled with.
+        /// </summary>
+        private static bool Implements(Type type, string interfaceName)
+        {
+            try { return type.GetInterfaces().Any(i => i.Name == interfaceName); }
+            catch { return false; }
+        }
+
+        private static IEnumerable<string> KindsOn(Type type)
+        {
+            IList<CustomAttributeData> attributes;
+            try { attributes = type.GetCustomAttributesData(); }
+            catch { yield break; }
+
+            foreach (var attribute in attributes)
+            {
+                if (attribute.AttributeType.Name != KindAttribute) continue;
+
+                var value = attribute.ConstructorArguments.FirstOrDefault().Value as string;
+                if (!string.IsNullOrWhiteSpace(value)) yield return value.Trim();
+            }
+        }
+    }
+}

--- a/SW.Serverless.Installer/Shared/CloudFilesFactory.cs
+++ b/SW.Serverless.Installer/Shared/CloudFilesFactory.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using SW.CloudFiles.AS.Extensions;
+// GC, OC, S3 and LocalTests all publish their registration extensions into this one namespace.
+using SW.CloudFiles.Extensions;
+using SW.PrimitiveTypes;
+
+namespace SW.Serverless.Installer.Shared
+{
+    /// <summary>
+    /// Builds the storage provider an adapter is published to.
+    ///
+    /// Each provider is constructed through its OWN registration extension rather than by newing
+    /// its service up here. That is not ceremony: those extensions create the bucket if it is
+    /// missing and set the temp1/temp7/temp30/temp365 lifecycle rules, so hand-rolling the
+    /// construction would publish into a bucket that quietly never expires anything.
+    /// </summary>
+    public static class CloudFilesFactory
+    {
+        /// <summary>Every provider name this tool accepts, for help text and error messages.</summary>
+        public static readonly IReadOnlyList<string> Providers = new[] { "s3", "as", "oc", "gc", "local" };
+
+        public static ICloudFilesService Create(ServerlessUploadOptions options)
+        {
+            var services = new ServiceCollection();
+
+            // The registration extensions bind their options from configuration, so a container
+            // without one throws before anything is registered. Empty is fine: everything these
+            // need has already been supplied on the command line or in the config file.
+            services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+
+            var provider = (options.Provider ?? "s3").ToLowerInvariant();
+
+            switch (provider)
+            {
+                case "as":
+                    services.AddAsCloudFiles(o =>
+                    {
+                        o.BucketName = options.BucketName;
+                        o.AccessKeyId = options.AccessKeyId;
+                        o.SecretAccessKey = options.SecretAccessKey;
+                        o.ServiceUrl = options.ServiceUrl;
+                    });
+                    break;
+
+                case "oc":
+                    services.AddOracleCloudFiles(o =>
+                    {
+                        o.BucketName = options.BucketName;
+                        o.AccessKeyId = options.AccessKeyId;
+                        o.SecretAccessKey = options.SecretAccessKey;
+                        o.ServiceUrl = options.ServiceUrl;
+                        o.Region = options.Region;
+                        o.FingerPrint = options.FingerPrint;
+                        o.TenantId = options.TenantId;
+                        o.UserId = options.UserId;
+                        o.RSAKey = options.RSAKey;
+                        o.NamespaceName = options.NamespaceName;
+                    });
+                    break;
+
+                case "gc":
+                    services.AddGoogleCloudFiles(o =>
+                    {
+                        o.BucketName = options.BucketName;
+                        o.ProjectId = options.ProjectId;
+                        o.PrivateKeyId = options.PrivateKeyId;
+                        o.PrivateKey = options.PrivateKey;
+                        o.ClientEmail = options.ClientEmail;
+                        o.ClientId = options.ClientId;
+                        if (!string.IsNullOrWhiteSpace(options.ClientX509CertUrl))
+                            o.ClientX509CertUrl = options.ClientX509CertUrl;
+                    });
+                    break;
+
+                case "local":
+                    // The filesystem provider, for a developer running Bitween against a local
+                    // store. Publishing to it is the same command with a different -p, rather than
+                    // the hand-built zip and .meta.json it used to take.
+                    services.AddLocalTestsCloudFiles(o =>
+                    {
+                        if (!string.IsNullOrWhiteSpace(options.BucketName))
+                            o.BucketName = options.BucketName;
+                        if (!string.IsNullOrWhiteSpace(options.ServiceUrl))
+                            o.StoragePath = options.ServiceUrl;
+                    });
+                    break;
+
+                case "s3":
+                    services.AddS3CloudFiles(o =>
+                    {
+                        o.BucketName = options.BucketName;
+                        o.AccessKeyId = options.AccessKeyId;
+                        o.SecretAccessKey = options.SecretAccessKey;
+                        o.ServiceUrl = options.ServiceUrl;
+                    });
+                    break;
+
+                default:
+                    throw new SWException(
+                        $"Unknown storage provider '{options.Provider}'. "
+                        + $"Expected one of: {string.Join(", ", Providers)}.");
+            }
+
+            return services.BuildServiceProvider().GetRequiredService<ICloudFilesService>();
+        }
+    }
+}

--- a/SW.Serverless.Installer/Shared/InstallerLogic.cs
+++ b/SW.Serverless.Installer/Shared/InstallerLogic.cs
@@ -99,47 +99,27 @@ namespace SW.Serverless.Installer.Shared
             }
         }
 
-        private static async Task<CloudFilesService> GetAzureStorageConfig(CloudFilesOptions cloudFilesOptions)
-        {
-            var blobContainerClient = new BlobServiceClient(
-                new Uri(cloudFilesOptions.ServiceUrl),
-                new StorageSharedKeyCredential(cloudFilesOptions.AccessKeyId,
-                    cloudFilesOptions.SecretAccessKey)).GetBlobContainerClient(cloudFilesOptions.BucketName);
 
-            return await blobContainerClient.ExistsAsync()
-                ? new CloudFilesService(blobContainerClient)
-                : new CloudFilesService(
-                    await new BlobServiceClient(new Uri(cloudFilesOptions.ServiceUrl),
-                            new StorageSharedKeyCredential(cloudFilesOptions.AccessKeyId,
-                                cloudFilesOptions.SecretAccessKey))
-                        .CreateBlobContainerAsync(cloudFilesOptions.BucketName));
-        }
 
-        private static Task<CloudFiles.S3.CloudFilesService> GetS3Config(CloudFilesOptions cloudFilesOptions)
-        {
-            return Task.FromResult(new CloudFiles.S3.CloudFilesService(cloudFilesOptions));
-        }
 
-        private static Task<CloudFiles.OC.CloudFilesService> GetOracleCloudConfigConfig(
-            OracleCloudFilesOptions options)
+        /// <summary>
+        /// What every uploaded adapter carries. Kind and Lifecycle are new, and both are written
+        /// even when empty so a host can tell "this adapter declared nothing" from "this adapter
+        /// predates the field" — the second still needs the old naming convention to classify it.
+        /// </summary>
+        private static Dictionary<string, string> BuildMetadata(
+            string entryAssembly, AdapterDescription description) => new()
         {
-            var directory = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location)!;
-            var pemPath = Path.Combine(directory, $"{Guid.NewGuid():N}.pem");
-            File.WriteAllText(pemPath, options.RSAKey);
-            var configPAth = Path.Combine(directory, $"{Guid.NewGuid():N}.config");
-            File.WriteAllText(configPAth, @$"[DEFAULT]
-user={options.UserId}
-fingerprint={options.FingerPrint}
-tenancy={options.TenantId}
-region={options.Region}
-key_file={pemPath}");
-            options.ConfigPath = configPAth;
-            return Task.FromResult(new CloudFiles.OC.CloudFilesService(options, null));
-        }
+            { "EntryAssembly", entryAssembly },
+            { "Lang", "dotnet" },
+            { "Timestamp", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ") },
+            { "Lifecycle", description?.Lifecycle ?? AdapterDescription.ClassicLifecycle },
+            { "Kind", description?.Kind ?? "" },
+        };
 
         private static async Task UploadVersioned(ICloudFilesService cloudService, Stream zipFileStream,
             string adapterId,
-            string entryAssembly, string version)
+            string entryAssembly, string version, AdapterDescription description)
         {
             var dir = $"adapters/{adapterId}".ToLower();
             var list = (await cloudService.ListAsync(dir)).ToList();
@@ -150,17 +130,12 @@ key_file={pemPath}");
             {
                 ContentType = "application/zip",
                 Key = path,
-                Metadata = new Dictionary<string, string>
-                {
-                    { "EntryAssembly", entryAssembly },
-                    { "Lang", "dotnet" },
-                    { "Timestamp", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ") }
-                }
+                Metadata = BuildMetadata(entryAssembly, description)
             });
         }
 
         private static async Task UploadLegacy(ICloudFilesService cloudService, Stream zipFileStream, string adapterId,
-            string entryAssembly)
+            string entryAssembly, AdapterDescription description)
         {
             var path = $"adapters/{adapterId}".ToLower();
             Console.WriteLine($"Uploading to {path}");
@@ -168,56 +143,39 @@ key_file={pemPath}");
             {
                 ContentType = "application/zip",
                 Key = path,
-                Metadata = new Dictionary<string, string>
-                {
-                    { "EntryAssembly", entryAssembly },
-                    { "Lang", "dotnet" },
-                    { "Timestamp", DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ") }
-                }
+                Metadata = BuildMetadata(entryAssembly, description)
             });
         }
 
         public async Task<bool> PushToCloud(
             string zipFilePath,
             string entryAssembly,
-            ServerlessUploadOptions options)
+            ServerlessUploadOptions options,
+            AdapterDescription description = null)
         {
             try
             {
                 Console.WriteLine("Starting...");
-                var cloudFilesOptions = new OracleCloudFilesOptions
-                {
-                    AccessKeyId = options.AccessKeyId,
-                    SecretAccessKey = options.SecretAccessKey,
-                    ServiceUrl = options.ServiceUrl,
-                    BucketName = options.BucketName,
-                    Region = options.Region,
-                    FingerPrint = options.FingerPrint,
-                    TenantId = options.TenantId,
-                    UserId = options.UserId,
-                    RSAKey = options.RSAKey,
-                    NamespaceName = options.NamespaceName,
-                };
-                ICloudFilesService cloudService = options.Provider?.ToLower() switch
-                {
-                    "as" => await GetAzureStorageConfig(cloudFilesOptions),
-                    "s3" => await GetS3Config(cloudFilesOptions),
-                    "oc" => await GetOracleCloudConfigConfig(cloudFilesOptions),
-                    _ => await GetS3Config(cloudFilesOptions),
-                };
+                var cloudService = CloudFilesFactory.Create(options);
                 Console.WriteLine("Reading file...");
 
                 await using var zipFileStream = File.OpenRead(zipFilePath);
                 Console.WriteLine("Pushing to cloud...");
 
+                description ??= new AdapterDescription();
+                Console.WriteLine(
+                    $"Lifecycle: {description.Lifecycle}"
+                    + (string.IsNullOrEmpty(description.Kind) ? "" : $", kind: {description.Kind}"));
+
                 if (string.IsNullOrWhiteSpace(options.Version))
                 {
-                    await UploadLegacy(cloudService, zipFileStream, options.AdapterId, entryAssembly);
+                    await UploadLegacy(cloudService, zipFileStream, options.AdapterId, entryAssembly,
+                        description);
                 }
                 else
                 {
                     await UploadVersioned(cloudService, zipFileStream, options.AdapterId, entryAssembly,
-                        options.Version);
+                        options.Version, description);
                 }
 
                 Console.WriteLine("Pushing to cloud succeeded.");

--- a/SW.Serverless.Samples.Classic/Handler.cs
+++ b/SW.Serverless.Samples.Classic/Handler.cs
@@ -12,6 +12,8 @@ namespace SW.Serverless.Samples.Classic
     /// adapters already use. Commands are public Task / Task&lt;T&gt; methods discovered by name;
     /// configuration comes from startup values; logging goes through AdapterLogger.
     /// </summary>
+    [AdapterKind("handler")]
+    [AdapterKind("mapper")]
     public class Handler
     {
         /// <summary>

--- a/SW.Serverless.Sdk/AdapterKindAttribute.cs
+++ b/SW.Serverless.Sdk/AdapterKindAttribute.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace SW.Serverless.Sdk
+{
+    /// <summary>
+    /// Declares what an adapter is FOR, so a host can offer it in the right place without being
+    /// told separately.
+    ///
+    /// The kind is a label this framework does not interpret — a host decides what "handler" or
+    /// "mapper" means to it. Declaring it here rather than encoding it in the adapter's id is what
+    /// lets an adapter be reclassified without being renamed, and a rename is not free: hosts store
+    /// the id against every configuration that uses the adapter.
+    ///
+    /// Apply more than once for an adapter that serves in several roles.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+    public class AdapterKindAttribute : Attribute
+    {
+        public AdapterKindAttribute(string kind) => Kind = kind;
+
+        /// <summary>e.g. "handler", "mapper", "receiver", "validator".</summary>
+        public string Kind { get; }
+    }
+}

--- a/SW.Serverless.UnitTests/SW.Serverless.UnitTests.csproj
+++ b/SW.Serverless.UnitTests/SW.Serverless.UnitTests.csproj
@@ -17,8 +17,8 @@
         <!-- Same version Bitween-api pins, so the monorepo stays on one Testcontainers. -->
         <PackageReference Include="Testcontainers.RabbitMq" Version="3.10.0" />
         <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
-        <PackageReference Include="SimplyWorks.CloudFiles.LocalTests" Version="8.1.6" />
-        <PackageReference Include="SimplyWorks.CloudFiles.LocalTests.Extensions" Version="8.1.6" />
+        <PackageReference Include="SimplyWorks.CloudFiles.LocalTests" Version="8.1.12" />
+        <PackageReference Include="SimplyWorks.CloudFiles.LocalTests.Extensions" Version="8.1.12" />
 
     </ItemGroup>
 


### PR DESCRIPTION
Two things a host had to guess at, and one it could not reach. **88 tests pass** (80 before).

## Kind and lifecycle, read from the assembly

The Installer now opens the published entry assembly and records what it finds — `"resident"` when a type implements `IResidentAdapter`, plus whatever roles are declared with the new `[AdapterKind]` attribute — into the object metadata beside `EntryAssembly` and `Hash`.

Read through **`MetadataLoadContext`**, so the assembly is *inspected* rather than loaded: nothing in the adapter executes and no static constructor runs. A publish cannot be made to do anything by the code it is packaging.

**Lifecycle is the one that mattered.** It could not be expressed at all before, so a resident adapter looked exactly like a classic one — which is how one ends up offered in a menu that can only run the other, then fails by waiting out a command timeout for an answer that was never coming. Bitween hits exactly this today.

**Kind is declared, not inferred.** Guessing would put an adapter in a menu where choosing it cannot work, so an adapter that declares nothing gets nothing, and `--kind` covers one whose author has not added the attribute yet.

Describing never fails a publish: an unreadable assembly describes as the classic, kind-less adapter every adapter was before this existed.

## Every storage provider

Google Cloud and the local filesystem provider join s3, Azure and Oracle. The local one is what a developer running against a local store needs — installing an adapter for it took a hand-built zip and `.meta.json` before.

Each provider is now built through its **own registration extension** rather than constructed in the installer. That is not ceremony:

- those extensions create the bucket if missing and set the `temp1/temp7/temp30/temp365` lifecycle rules, so the hand-rolled construction was publishing into buckets that **quietly never expired anything**;
- it had already drifted — the Azure constructor had gained a parameter and the old code no longer compiled against the current package.

CloudFiles packages aligned to 8.1.12 across the installer and the test project; the pins were years apart from the extensions that depend on them.

## Tests

A real resident sample described as resident **and a real classic one as classic** — the second matters, or the check could be returning `"resident"` for everything and every other test would still pass. Plus declared kinds read from the assembly, an adapter declaring none getting none, a missing assembly and a missing directory describing as classic rather than throwing, and the provider list and its error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)